### PR TITLE
[#40] homefragment의 버튼 안보임 해결 작가 보여주기 divider 제거

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
@@ -199,8 +199,7 @@ class HomeFragment : Fragment() {
             recyclerViewAuthor.apply {
                 adapter = AuthorListRecycler()
                 layoutManager = LinearLayoutManager(mainActivity, LinearLayoutManager.HORIZONTAL, false)
-                val deco = MaterialDividerItemDecoration(mainActivity, MaterialDividerItemDecoration.HORIZONTAL)
-                addItemDecoration(deco)
+
             }
         }
     }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -147,6 +147,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="40dp"
                 android:layout_marginTop="40dp"
+                android:layout_marginBottom="100dp"
                 android:background="@drawable/button_radius"
                 android:text="전시실 방문 신청"
                 android:textColor="@color/white"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #40 

## 📝작업 내용

> HomeFragment의 전시실 방문 신청 버튼 수정 및 Recyclerview의 deco(Divider) 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 전시실 방문 버튼이 xml에선 존재하는데 단말기에서 나오지를 않아서 marginBottom을 줬는데 이렇게 하니까 잘 보이더라구요
혹시 더 나은 방법이 있을까요,,?
>
> 
