### PR TITLE
[#65] homefragment의 작가 recyclerview 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/home/AuthorAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/home/AuthorAdapter.kt
@@ -6,7 +6,15 @@ import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.AuthorListBinding
 
+
 class AuthorAdapter : RecyclerView.Adapter<AuthorViewHolder>() {
+
+    private lateinit var authorItemClickListener:AuthorOnClickListener
+
+    fun setRecyclerviewClickListener(authorItemOnClickListener: AuthorOnClickListener){
+        this.authorItemClickListener = authorItemOnClickListener
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorViewHolder {
 
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -23,6 +31,13 @@ class AuthorAdapter : RecyclerView.Adapter<AuthorViewHolder>() {
     override fun onBindViewHolder(holder: AuthorViewHolder, position: Int) {
         holder.authorListBinding.imageAuthorNameList.setImageResource(R.drawable.mypage_icon)
         holder.authorListBinding.textAuthorNameList.text = "작가명"
+        holder.authorListBinding.root.setOnClickListener {
+            authorItemClickListener.authorItemClickListener()
+        }
+    }
+
+    interface AuthorOnClickListener{
+        fun authorItemClickListener()
     }
 }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/home/AuthorAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/home/AuthorAdapter.kt
@@ -1,0 +1,35 @@
+package kr.co.lion.unipiece.ui.home
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.databinding.AuthorListBinding
+
+class AuthorAdapter : RecyclerView.Adapter<AuthorViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorViewHolder {
+
+        val layoutInflater = LayoutInflater.from(parent.context)
+
+        val authorListBinding = AuthorListBinding.inflate(layoutInflater)
+        val authorViewHolder = AuthorViewHolder(authorListBinding)
+        return authorViewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return 15
+    }
+
+    override fun onBindViewHolder(holder: AuthorViewHolder, position: Int) {
+        holder.authorListBinding.imageAuthorNameList.setImageResource(R.drawable.mypage_icon)
+        holder.authorListBinding.textAuthorNameList.text = "작가명"
+    }
+}
+
+class AuthorViewHolder(authorListBinding: AuthorListBinding):RecyclerView.ViewHolder(authorListBinding.root){
+    val authorListBinding: AuthorListBinding
+
+    init {
+        this.authorListBinding = authorListBinding
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
@@ -38,7 +38,24 @@ class HomeFragment : Fragment() {
     val handler = Handler(Looper.getMainLooper())
 
     val authorAdapter:AuthorAdapter by lazy {
-        AuthorAdapter()
+        var adapter = AuthorAdapter()
+        adapter.setRecyclerviewClickListener(object : AuthorAdapter.AuthorOnClickListener{
+            override fun authorItemClickListener() {
+                val dialog = CustomDialog("성공", "클릭 이벤트\n나중에 수정합니다!")
+                dialog.setButtonClickListener(object :CustomDialog.OnButtonClickListener{
+                    override fun okButtonClick() {
+
+                    }
+
+                    override fun noButtonClick() {
+
+                    }
+
+                })
+                dialog.show(mainActivity.supportFragmentManager, "CustomDialog")
+            }
+        })
+        adapter
     }
 
     override fun onCreateView(

--- a/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/home/HomeFragment.kt
@@ -37,6 +37,10 @@ class HomeFragment : Fragment() {
     val timer = Timer()
     val handler = Handler(Looper.getMainLooper())
 
+    val authorAdapter:AuthorAdapter by lazy {
+        AuthorAdapter()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
@@ -203,41 +207,15 @@ class HomeFragment : Fragment() {
         }, 4000, 4000)
     }
 
-    private fun settingAdapter(){
+    private fun settingAdapter() {
         fragmentHomeBinding.apply {
             recyclerViewAuthor.apply {
-                adapter = AuthorListRecycler()
-                layoutManager = LinearLayoutManager(mainActivity, LinearLayoutManager.HORIZONTAL, false)
+                adapter = authorAdapter
+                layoutManager =
+                    LinearLayoutManager(mainActivity, LinearLayoutManager.HORIZONTAL, false)
 
             }
         }
     }
-
-    inner class AuthorListRecycler : RecyclerView.Adapter<AuthorListRecycler.AuthorViewHolder>(){
-
-        inner class AuthorViewHolder(authorListBinding: AuthorListBinding):RecyclerView.ViewHolder(authorListBinding.root){
-            val authorListBinding:AuthorListBinding
-
-            init {
-                this.authorListBinding = authorListBinding
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorViewHolder {
-            val authorListBinding = AuthorListBinding.inflate(layoutInflater)
-            val authorViewHolder = AuthorViewHolder(authorListBinding)
-            return authorViewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 15
-        }
-
-        override fun onBindViewHolder(holder: AuthorViewHolder, position: Int) {
-            holder.authorListBinding.imageAuthorNameList.setImageResource(R.drawable.mypage_icon)
-            holder.authorListBinding.textAuthorNameList.text = "작가명"
-        }
-    }
-
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #65 

## 📝작업 내용

> HomeFragment에 있는 작가 Recyclerview의 adapter를 분리하고 클릭 이벤트를 구현했습니다

### 스크린샷 (선택)
![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/157032240/96a4e980-df28-43af-8e28-40d77006345c)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
