### PR TITLE
[#77] 뒤로가기 오류들 해결

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -29,7 +29,7 @@ class MainActivity : AppCompatActivity() {
         bottomNaviClick()
         initView()
         setBuyNaviDrawer()
-        setOpenFragment()
+        openSearchFragment()
     }
 
     fun printFragmentBackStack(name: String) {
@@ -134,8 +134,8 @@ class MainActivity : AppCompatActivity() {
             if(drawerBuyLayout.isDrawerOpen(GravityCompat.START)){
                 drawerBuyLayout.close()
             } else {
-
                 var isSearchFragmentOnTop = false
+
                 if (supportFragmentManager.backStackEntryCount > 0) {
                     // 백 스택의 마지막 항목의 이름을 가져옵니다.
                     val lastFragmentName = supportFragmentManager.getBackStackEntryAt(supportFragmentManager.backStackEntryCount - 1).name
@@ -149,10 +149,12 @@ class MainActivity : AppCompatActivity() {
                 if (isSearchFragmentOnTop) {
                     // SearchFragment가 백 스택의 최상단에 존재합니다.
                     // 안드로이드 뒤로가기 버튼 실행 -> searchresultfragment에서 뒤로갔을때 searchfragment로 가지 않고 그 전으로 가기
+                    printFragmentBackStack("two back")
                     super.onBackPressed()
                     super.onBackPressed()
                 } else {
                     // 안드로이드 뒤로가기 버튼 실행
+                    printFragmentBackStack("one back")
                     super.onBackPressed()
                 }
 
@@ -162,13 +164,12 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 updateBottomNavi()
-                printFragmentBackStack("back")
             }
         }
     }
 
     fun updateBottomNavi(){
-        printFragmentBackStack("update")
+        // printFragmentBackStack("update")
         val fragment = supportFragmentManager.findFragmentById(R.id.fl_container)
         when(fragment) {
             is HomeFragment -> {
@@ -194,7 +195,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
     fun bottomNaviClick() {
-        printFragmentBackStack("navi")
+        // printFragmentBackStack("navi")
         binding.bottomNavigationView.setOnItemSelectedListener {
             when(it.itemId) {
                 R.id.fragment_home -> {
@@ -276,15 +277,18 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.popBackStack(name.str, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     }
 
-    fun setOpenFragment() {
+    fun openSearchFragment() {
 
-        if (intent.getBooleanExtra("SearchFragment", false)) {
-            replaceFragment(SEARCH_FRAGMENT, true)
-        }
-        if(intent.getBooleanExtra("BuyFragment", false)) {
-            replaceFragment(BUY_FRAGMENT, true)
+        if (intent.getBooleanExtra(RANK_FRAGMENT.str, false)
+            || intent.getBooleanExtra(BUY_FRAGMENT.str, false)) {
+
+            supportFragmentManager.popBackStack()
+
+            if(intent.getBooleanExtra("SearchFragment", false)){
+                replaceFragment(SEARCH_FRAGMENT, true)
+            }
+
         }
 
-        updateBottomNavi()
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -279,15 +279,40 @@ class MainActivity : AppCompatActivity() {
 
     fun openSearchFragment() {
 
-        if (intent.getBooleanExtra(RANK_FRAGMENT.str, false)
-            || intent.getBooleanExtra(BUY_FRAGMENT.str, false)) {
-
-            supportFragmentManager.popBackStack()
-
+        /*if (intent.getBooleanExtra(RANK_FRAGMENT.str, false)) {
+            binding.bottomNavigationView.selectedItemId = R.id.fragment_rank
             if(intent.getBooleanExtra("SearchFragment", false)){
+                supportFragmentManager.popBackStack()
+                supportFragmentManager.popBackStack()
                 replaceFragment(SEARCH_FRAGMENT, true)
             }
+        }
+        if (intent.getBooleanExtra(BUY_FRAGMENT.str, false)) {
+            binding.bottomNavigationView.selectedItemId = R.id.fragment_buy
 
+            if(intent.getBooleanExtra("SearchFragment", false)){
+                supportFragmentManager.popBackStack()
+                supportFragmentManager.popBackStack()
+                replaceFragment(SEARCH_FRAGMENT, true)
+            }
+        }*/
+
+        val isRankFragment = intent.getBooleanExtra(RANK_FRAGMENT.str, false)
+        val isBuyFragment = intent.getBooleanExtra(BUY_FRAGMENT.str, false)
+        val isSearchFragment = intent.getBooleanExtra(SEARCH_FRAGMENT.str, false)
+
+        // RANK_FRAGMENT 또는 BUY_FRAGMENT가 true인 경우에만 로직을 실행합니다.
+        if (isRankFragment || isBuyFragment) {
+
+            // 선택된 탭을 설정합니다.
+            binding.bottomNavigationView.selectedItemId = if (isRankFragment) R.id.fragment_rank else R.id.fragment_buy
+
+            // SearchFragment가 true인 경우 프래그먼트 변경 로직을 실행합니다.
+            if (isSearchFragment) {
+                supportFragmentManager.popBackStack()
+                supportFragmentManager.popBackStack()
+                replaceFragment(SEARCH_FRAGMENT, true)
+            }
         }
 
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
@@ -3,6 +3,7 @@ package kr.co.lion.unipiece.ui.buy
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityBuyDetailBinding
 import kr.co.lion.unipiece.ui.MainActivity
@@ -54,7 +55,13 @@ class BuyDetailActivity : AppCompatActivity() {
     }
 
     fun setIntent(name: String) {
+        val buyIntent = intent.getBooleanExtra("BuyFragment", false)
+        val rankIntent = intent.getBooleanExtra("RankFragment", false)
+
         val intent = Intent(this@BuyDetailActivity, MainActivity::class.java)
+        intent.putExtra("RankFragment", rankIntent)
+        intent.putExtra("BuyFragment", buyIntent)
+
         intent.putExtra(name, true)
         startActivity(intent)
         finish()

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -54,7 +54,7 @@ class BuyFragment : Fragment() {
                     when (menuItem.itemId) {
                         R.id.menu_search -> {
                             val fragmentManager = activity?.supportFragmentManager?.beginTransaction()
-                            fragmentManager?.replace(R.id.fl_container, SearchFragment())?.addToBackStack("BuyFragment")?.commit()
+                            fragmentManager?.replace(R.id.fl_container, SearchFragment())?.addToBackStack(null)?.commit()
                             true
                         }
                         R.id.menu_cart -> {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
@@ -42,8 +42,9 @@ class BuyNewFragment : Fragment() {
 
         adapter = BuyNewAdapter(testImageList,
             itemClickListener = { testReviewId ->
-                Log.d("test", testReviewId.toString())
-                startActivity(Intent(requireActivity(), BuyDetailActivity::class.java))
+                val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+                intent.putExtra("BuyFragment", true)
+                startActivity(intent)
             }
         )
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
@@ -38,8 +38,9 @@ class BuyPopFragment : Fragment() {
 
         adapter = BuyPopAdapter(testImageList,
             itemClickListener = { testReviewId ->
-                Log.d("test", testReviewId.toString())
-                startActivity(Intent(requireActivity(), BuyDetailActivity::class.java))
+                val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+                intent.putExtra("BuyFragment", true)
+                startActivity(intent)
             }
         )
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFragment.kt
@@ -80,22 +80,20 @@ class RankFragment : Fragment() {
 
     private fun setFragment(name: RankFragmentName) {
 
-        val fragmentMananger = childFragmentManager.beginTransaction()
+        val fragmentMananger = activity?.supportFragmentManager?.beginTransaction()
 
             when(name) {
                 RANK_PIECE_FRAGMENT -> {
-                    fragmentMananger.replace(R.id.rank_fragment, RankPieceFragment())
+                    fragmentMananger?.replace(R.id.rank_fragment, RankPieceFragment())
                     binding.rankTitle.text = "작품 랭킹"
                 }
                 RANK_AUTHOR_FRAGMENT -> {
-                    fragmentMananger.replace(R.id.rank_fragment, RankAuthorFragment())
-                    binding.rankTitle.text ="작가 랭킹"
+                    fragmentMananger?.replace(R.id.rank_fragment, RankAuthorFragment())
+                    binding.rankTitle.text = "작가 랭킹"
                 }
             }
-
-        fragmentMananger.setReorderingAllowed(true)
-        fragmentMananger.addToBackStack(name.str)
-        fragmentMananger.commit()
+        fragmentMananger?.addToBackStack(name.str)
+        fragmentMananger?.commit()
     }
 
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankPieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankPieceFragment.kt
@@ -23,7 +23,9 @@ class RankPieceFragment : Fragment() {
     val adapter: RankPieceAdapter by lazy {
         RankPieceAdapter(testPieceList,
             itemClickListener = { testId ->
-                startActivity(Intent(requireActivity(), BuyDetailActivity::class.java))
+                val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+                intent.putExtra("RankFragment", true)
+                startActivity(intent)
             })
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/adapter/RankAuthorVPAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/adapter/RankAuthorVPAdapter.kt
@@ -22,7 +22,7 @@ class RankAuthorVPAdapter (fragmentActivity: FragmentActivity) : FragmentStateAd
 
     fun removeFragement() {
         fragments.removeLast()
-        notifyItemRemoved(fragments.size)
+        notifyItemRemoved(fragments.size - 1)
     }
 
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
@@ -33,7 +33,8 @@ class SearchFragment : Fragment() {
     fun settingToolbarSearch(){
         with(binding.toolbarSearch) {
             setNavigationOnClickListener {
-                activity?.supportFragmentManager?.popBackStack()
+                activity?.onBackPressed()
+                activity?.onBackPressed()
             }
 
             inflateMenu(R.menu.menu_cart)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
@@ -62,8 +62,28 @@ class SearchResultFragment : Fragment() {
     fun settingToolbarSearchResult(){
         with(binding.toolbarSearchResult) {
             setNavigationOnClickListener {
-                activity?.supportFragmentManager?.popBackStack()
-                activity?.supportFragmentManager?.popBackStack()
+
+                val supportFragmentManager = activity?.supportFragmentManager
+
+                var isSearchFragmentOnTop = false
+                val count = supportFragmentManager?.backStackEntryCount ?: 0
+                if (count > 0) {
+                    // 백 스택의 마지막 항목의 이름을 가져옵니다.
+                    val lastFragmentName = activity?.supportFragmentManager?.getBackStackEntryAt(count - 1)?.name
+                    // 마지막 항목의 이름이 "SearchFragment"와 일치하는지 확인합니다.
+                    isSearchFragmentOnTop = "SearchFragment" == lastFragmentName
+                } else {
+                    // 백 스택이 비어있으면, SearchFragment가 최상단에 있을 수 없습니다.
+                    isSearchFragmentOnTop = false
+                }
+
+                if(isSearchFragmentOnTop) {
+                    activity?.onBackPressed()
+                    activity?.onBackPressed()
+                } else {
+                    activity?.onBackPressed()
+                }
+
             }
 
             inflateMenu(R.menu.menu_cart)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) [Fix] 뒤로가기 오류들 수정 #77

## 📝작업 내용

> 뒤로가기에 관련된 오류들 해결했습니다.

1. 작품구매 or 랭킹 화면 → 작품 상세보기 화면 → 검색버튼 클릭 → 검색 프레그먼트 → navigation 뒤로가기 버튼 눌렀을 때 작품 구매 탭이 아니라 home 화면으로 오게 됨
2. 랭킹 → 작가랭킹 → 검색버튼 → 안드로이드 뒤로가기, 네이게이션 버튼 → 앱 종료 오류

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
