### PR TITLE
[Feat] #88 마이페이지, 팔로우 목록 화면 구현. 패키지 정리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:theme="@style/Theme.UniPiece"
         tools:targetApi="31">
         <activity
+            android:name=".ui.mypage.FollowActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.payment.delivery.DeliveryActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
@@ -1,0 +1,93 @@
+package kr.co.lion.unipiece.ui.mypage
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.ViewGroup
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.databinding.ActivityFollowBinding
+import kr.co.lion.unipiece.databinding.RowFollowBinding
+import kr.co.lion.unipiece.ui.MainActivity
+
+class FollowActivity : AppCompatActivity() {
+
+    lateinit var activityFollowBinding: ActivityFollowBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        activityFollowBinding = ActivityFollowBinding.inflate(layoutInflater)
+        setContentView(activityFollowBinding.root)
+
+
+        setToolbar()
+        setRecyclerViewFollow()
+
+    }
+
+    // 툴바 셋팅
+    fun setToolbar(){
+        activityFollowBinding.apply {
+            toolbarFollowAuthor.apply {
+                // 뒤로가기 아이콘
+                setNavigationIcon(R.drawable.back_icon)
+                setNavigationOnClickListener {
+                    finish()
+                }
+            }
+        }
+    }
+
+    // 메인 화면의 RecyclerView 설정
+    fun setRecyclerViewFollow(){
+        activityFollowBinding.apply {
+            recyclerViewFollowAuthorList.apply {
+                // 어뎁터
+                adapter = MainRecyclerViewAdapter()
+                // 레이아웃 매니저
+                layoutManager = GridLayoutManager(this@FollowActivity,2)
+            }
+        }
+    }
+
+    // 메인 화면의 RecyclerView의 어뎁터
+    inner class MainRecyclerViewAdapter :
+        RecyclerView.Adapter<MainRecyclerViewAdapter.MainViewHolder>() {
+        inner class MainViewHolder(rowFollowBinding: RowFollowBinding) :
+            RecyclerView.ViewHolder(rowFollowBinding.root) {
+            val rowFollowBinding: RowFollowBinding
+
+            init {
+                this.rowFollowBinding = rowFollowBinding
+
+                // 항목별 팔로잉 버튼 클릭 시
+                this.rowFollowBinding.buttonFollowListFollowing.setOnClickListener {
+                    // 속이 빈 버튼모양으로 변경
+                }
+
+                this.rowFollowBinding.root.layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MainViewHolder {
+            val rowFollowBinding = RowFollowBinding.inflate(layoutInflater)
+            val mainViewHolder = MainViewHolder(rowFollowBinding)
+            return mainViewHolder
+        }
+
+        override fun getItemCount(): Int {
+            return 10
+        }
+
+        override fun onBindViewHolder(holder: MainViewHolder, position: Int) {
+            holder.rowFollowBinding.textViewFollowListAuthorName.text = "홍길동"
+        }
+
+
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/MyPageFragment.kt
@@ -1,60 +1,112 @@
 package kr.co.lion.unipiece.ui.mypage
 
+
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.databinding.FragmentMyPageBinding
+import kr.co.lion.unipiece.ui.MainActivity
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
+import kr.co.lion.unipiece.util.MainFragmentName
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [MyPageFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class MyPageFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    lateinit var fragmentMyPageBinding: FragmentMyPageBinding
+    lateinit var mainActivity: MainActivity
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        fragmentMyPageBinding = FragmentMyPageBinding.inflate(layoutInflater)
+        mainActivity = activity as MainActivity
+
+        setToolbar()
+        clickButtonFollowAuthor()
+
+        return fragmentMyPageBinding.root
+    }
+
+    // 툴바 셋팅
+    fun setToolbar(){
+        fragmentMyPageBinding.apply {
+            materialToolbar.apply {
+
+                // 장바구니가 있는 메뉴 셋팅
+                inflateMenu(R.menu.menu_cart)
+                // 장바구니 메뉴 클릭 시
+                setOnMenuItemClickListener {
+                    when(it.itemId) {
+                        R.menu.menu_cart -> {
+                            val cartIntent = Intent(requireActivity(), CartActivity::class.java)
+                            startActivity(cartIntent)
+                            requireActivity().finish()
+                        }
+
+                    }
+                    true
+                }
+                // 뒤로가기 메뉴 셋팅
+                setNavigationIcon(R.drawable.back_icon)
+                // 뒤로가기 내비 아이콘 클릭 시
+                setNavigationOnClickListener {
+                    mainActivity.replaceFragment(MainFragmentName.HOME_FRAGMENT,false)
+                }
+            }
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_my_page, container, false)
+    // 회원 정보 보기
+    fun clickButtonUserInfo(){
+        with(fragmentMyPageBinding){
+            // 회원 정보 보기 버튼 클릭 시
+            textButtonMyPageInfo.setOnClickListener{
+
+            }
+        }
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment MyPageFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            MyPageFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
+    // 전시실 방문 신청 목록
+    fun clickButtonVisitGallery(){
+        with(fragmentMyPageBinding){
+            // 전시실 방문 신청 목록 버튼 클릭 시
+            textButtonMyPageVisitList.setOnClickListener{
+
             }
+        }
+    }
+
+    // 팔로잉한 작가
+    fun clickButtonFollowAuthor(){
+        with(fragmentMyPageBinding){
+            // 팔로잉한 작가 버튼 클릭 시
+            textButtonMyPageFollowAuth.setOnClickListener {
+                val followIntent = Intent(requireActivity(), FollowActivity::class.java)
+                startActivity(followIntent)
+            }
+        }
+    }
+
+    // 작가 정보 보기
+    fun clickButtonAuthorInfo(){
+        with(fragmentMyPageBinding){
+            // 작가 정보 보기 버튼 클릭 시
+            textButtonMyPageAuthInfo.setOnClickListener {
+
+            }
+        }
+    }
+
+    // 로그아웃
+    fun clickButtonLogout(){
+        with(fragmentMyPageBinding){
+            // 로그아웃 버튼 클릭 시
+            textButtonMyPageLogout.setOnClickListener {
+
+            }
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/util/FragmentUtil.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/util/FragmentUtil.kt
@@ -68,3 +68,4 @@ enum class DeliveryFragmentName(var str:String){
     DELIVERY_MANAGER_FRAGMENT("DeliveryManagerFragment"),
     DELIVERY_ADD_FRAGMENT("DeliveryAddFragment"),
 }
+

--- a/app/src/main/res/layout/activity_follow.xml
+++ b/app/src/main/res/layout/activity_follow.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbarFollowAuthor"
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:background="@color/white"/>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewFollowAuthorList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="20dp"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -24,13 +24,15 @@
             android:layout_height="wrap_content"
             android:fontFamily="@font/pretendard_extrabold"
             android:text="닉네임"
-            android:textSize="40sp" />
+            android:textColor="@color/black"
+            android:textSize="30sp" />
 
         <TextView
             android:id="@+id/textViewMyPageAuth"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
+            android:textColor="@color/black"
             android:text="작가" />
 
         <TextView
@@ -38,6 +40,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="right|center_vertical"
+            android:textColor="@color/black"
             android:clickable="true"
             android:text="회원 정보 보기"
             android:textAlignment="textEnd" />
@@ -55,6 +58,7 @@
             android:layout_height="wrap_content"
             android:clickable="true"
             android:fontFamily="@font/pretendard_semibold"
+            android:textColor="@color/black"
             android:text="전시실 방문 신청 목록" />
     </LinearLayout>
     <com.google.android.material.divider.MaterialDivider
@@ -75,6 +79,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/pretendard_semibold"
+            android:textColor="@color/black"
             android:text="팔로잉한 작가" />
     </LinearLayout>
     <com.google.android.material.divider.MaterialDivider
@@ -95,6 +100,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/pretendard_semibold"
+            android:textColor="@color/black"
             android:text="작가 정보 보기" />
     </LinearLayout>
     <com.google.android.material.divider.MaterialDivider
@@ -117,6 +123,7 @@
             android:drawableLeft="@drawable/logout_icon"
             android:fontFamily="@font/pretendard_semibold"
             android:text=" 로그아웃"
+            android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -1,14 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.mypage.MyPageFragment">
+    android:orientation="vertical">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/materialToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:background="@color/white" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="30dp">
+
+        <TextView
+            android:id="@+id/textViewMyPageNicName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_extrabold"
+            android:text="닉네임"
+            android:textSize="40sp" />
+
+        <TextView
+            android:id="@+id/textViewMyPageAuth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="작가" />
+
+        <TextView
+            android:id="@+id/textButtonMyPageInfo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right|center_vertical"
+            android:clickable="true"
+            android:text="회원 정보 보기"
+            android:textAlignment="textEnd" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textButtonMyPageVisitList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="전시실 방문 신청 목록" />
+    </LinearLayout>
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:theme="@style/Theme.Material3"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textButtonMyPageFollowAuth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="팔로잉한 작가" />
+    </LinearLayout>
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:theme="@style/Theme.Material3"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textButtonMyPageAuthInfo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="작가 정보 보기" />
+    </LinearLayout>
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:theme="@style/Theme.Material3"/>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="mypage" />
+        android:padding="20dp">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/textButtonMyPageLogout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:drawableLeft="@drawable/logout_icon"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text=" 로그아웃"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/row_follow.xml
+++ b/app/src/main/res/layout/row_follow.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Widget.Material3.CardView.Outlined"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
+        android:layout_marginBottom="10dp"
+        android:theme="@style/Theme.Material3"
+        app:cardBackgroundColor="@color/white"
+        app:strokeColor="@color/first"
+        app:strokeWidth="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/iv_profile_image"
+                android:layout_width="93dp"
+                android:layout_height="93dp"
+                android:layout_gravity="center"
+                android:layout_marginStart="38dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="41dp"
+                android:layout_marginBottom="20dp"
+                app:cardCornerRadius="50dp">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/icon" />
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/textViewFollowListAuthorName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:fontFamily="@font/pretendard_extrabold"
+                android:text="홍길동"
+                android:textAlignment="center"
+                android:textSize="20sp" />
+
+            <Button
+                android:id="@+id/buttonFollowListFollowing"
+                android:layout_width="100dp"
+                android:layout_height="30dp"
+                android:layout_gravity="center"
+                android:layout_marginBottom="10dp"
+                android:background="@drawable/button_radius"
+                android:padding="0dp"
+                android:text="팔로잉"
+                android:textColor="@color/white" />
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #88 

## 📝작업 내용

> 마이페이지, 팔로우 목록 화면구현 

### 스크린샷 (선택)

![111](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/0dca4783-0816-43f3-8e5a-514aa8975bb2) ![222](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/4436a9b9-b4d4-4d65-a3f6-f4e4ef0c390c)


## 💬리뷰 요구사항(선택)

로그아웃을 하단으로 줘도 자꾸 위로 올라와서 오늘 이동 작업 간에 팔로우버튼 동작이랑 같이 고쳐보겠습니다 ㅎㅎ
팔로우액티비티도 결제패키지에 있는게 직관적이진 않아서 마이페이지 탭으로 같이 옮겼습니다!