### PR TITLE
[#92] 나의 갤러리 관심작품에서 검색 화면으로 이동기능 추가

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -279,33 +279,22 @@ class MainActivity : AppCompatActivity() {
 
     fun openSearchFragment() {
 
-        /*if (intent.getBooleanExtra(RANK_FRAGMENT.str, false)) {
-            binding.bottomNavigationView.selectedItemId = R.id.fragment_rank
-            if(intent.getBooleanExtra("SearchFragment", false)){
-                supportFragmentManager.popBackStack()
-                supportFragmentManager.popBackStack()
-                replaceFragment(SEARCH_FRAGMENT, true)
-            }
-        }
-        if (intent.getBooleanExtra(BUY_FRAGMENT.str, false)) {
-            binding.bottomNavigationView.selectedItemId = R.id.fragment_buy
-
-            if(intent.getBooleanExtra("SearchFragment", false)){
-                supportFragmentManager.popBackStack()
-                supportFragmentManager.popBackStack()
-                replaceFragment(SEARCH_FRAGMENT, true)
-            }
-        }*/
-
         val isRankFragment = intent.getBooleanExtra(RANK_FRAGMENT.str, false)
         val isBuyFragment = intent.getBooleanExtra(BUY_FRAGMENT.str, false)
+        val isMyGalleryFragment = intent.getBooleanExtra(MY_GALLERY_FRAGMENT.str, false)
         val isSearchFragment = intent.getBooleanExtra(SEARCH_FRAGMENT.str, false)
 
-        // RANK_FRAGMENT 또는 BUY_FRAGMENT가 true인 경우에만 로직을 실행합니다.
-        if (isRankFragment || isBuyFragment) {
+        // RANK_FRAGMENT 또는 BUY_FRAGMENT 또는 MY_GALLERY가 true인 경우에만 로직을 실행합니다.
+        if (isRankFragment || isBuyFragment || isMyGalleryFragment) {
 
             // 선택된 탭을 설정합니다.
-            binding.bottomNavigationView.selectedItemId = if (isRankFragment) R.id.fragment_rank else R.id.fragment_buy
+             if (isRankFragment) {
+                binding.bottomNavigationView.selectedItemId = R.id.fragment_rank
+            } else if (isBuyFragment) {
+                 binding.bottomNavigationView.selectedItemId = R.id.fragment_buy
+            } else {
+                binding.bottomNavigationView.selectedItemId = R.id.fragment_mygallery
+             }
 
             // SearchFragment가 true인 경우 프래그먼트 변경 로직을 실행합니다.
             if (isSearchFragment) {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
@@ -3,11 +3,10 @@ package kr.co.lion.unipiece.ui.buy
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityBuyDetailBinding
 import kr.co.lion.unipiece.ui.MainActivity
-import kr.co.lion.unipiece.ui.search.SearchFragment
+import kr.co.lion.unipiece.util.MainFragmentName.*
 import kr.co.lion.unipiece.util.setMenuIconColor
 
 class BuyDetailActivity : AppCompatActivity() {
@@ -55,12 +54,14 @@ class BuyDetailActivity : AppCompatActivity() {
     }
 
     fun setIntent(name: String) {
-        val buyIntent = intent.getBooleanExtra("BuyFragment", false)
-        val rankIntent = intent.getBooleanExtra("RankFragment", false)
+        val buyIntent = intent.getBooleanExtra(BUY_FRAGMENT.str, false)
+        val rankIntent = intent.getBooleanExtra(RANK_FRAGMENT.str, false)
+        val mygalleryIntent = intent.getBooleanExtra(MY_GALLERY_FRAGMENT.str, false)
 
         val intent = Intent(this@BuyDetailActivity, MainActivity::class.java)
         intent.putExtra("RankFragment", rankIntent)
         intent.putExtra("BuyFragment", buyIntent)
+        intent.putExtra("MyGalleryFragment", mygalleryIntent)
 
         intent.putExtra(name, true)
         startActivity(intent)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/InterestingPieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/InterestingPieceFragment.kt
@@ -27,7 +27,9 @@ class InterestingPieceFragment : Fragment() {
 
     val interestingPieceAdapter: InterestingPieceAdapter by lazy {
         InterestingPieceAdapter { position ->
-            startActivity(Intent(requireActivity(), BuyDetailActivity::class.java))
+            val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+            intent.putExtra("MyGalleryFragment", true)
+            startActivity(intent)
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) [Feature] 나의 갤러리 관심작품 검색 화면 이동 #92

## 📝작업 내용

> 나의 갤러리에서 관심작품 리스트에서 작품을 누르면 작품 상세 화면으로 이동한다.
작품 상세 화면으로 이동했을 때, 툴바에 있는 검색 버튼을 누르면 검색 화면으로 이동한다.
