### PR TITLE
[#89] 작품 구매 및 랭킹 화면 이동 기능 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityBuyDetailBinding
 import kr.co.lion.unipiece.ui.MainActivity
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.util.MainFragmentName.*
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -23,6 +24,8 @@ class BuyDetailActivity : AppCompatActivity() {
 
         setToolbar()
         likeBtnClick()
+        cartBtnClick()
+
     }
 
     fun setToolbar(){
@@ -81,4 +84,14 @@ class BuyDetailActivity : AppCompatActivity() {
             }
         }
     }
+
+    fun cartBtnClick() {
+        with(binding.cartBtn){
+            setOnClickListener {
+                val intent = Intent(this@BuyDetailActivity, CartActivity::class.java)
+                startActivity(intent)
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
@@ -7,6 +7,7 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityBuyDetailBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.payment.cart.CartActivity
+import kr.co.lion.unipiece.ui.payment.order.OrderActivity
 import kr.co.lion.unipiece.util.MainFragmentName.*
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -25,6 +26,7 @@ class BuyDetailActivity : AppCompatActivity() {
         setToolbar()
         likeBtnClick()
         cartBtnClick()
+        buyBtnClick()
 
     }
 
@@ -86,9 +88,18 @@ class BuyDetailActivity : AppCompatActivity() {
     }
 
     fun cartBtnClick() {
-        with(binding.cartBtn){
+        with(binding.cartBtn) {
             setOnClickListener {
                 val intent = Intent(this@BuyDetailActivity, CartActivity::class.java)
+                startActivity(intent)
+            }
+        }
+    }
+
+    fun buyBtnClick() {
+        with(binding.buyBtn) {
+            setOnClickListener {
+                val intent = Intent(this@BuyDetailActivity, OrderActivity::class.java)
                 startActivity(intent)
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.buy
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -12,6 +13,7 @@ import kr.co.lion.unipiece.databinding.FragmentBuyBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.search.SearchFragment
 import kr.co.lion.unipiece.ui.buy.adapter.BuyAdapter
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.util.setMenuIconColor
 
 class BuyFragment : Fragment() {
@@ -58,7 +60,8 @@ class BuyFragment : Fragment() {
                             true
                         }
                         R.id.menu_cart -> {
-
+                            val intent = Intent(requireActivity(), CartActivity::class.java)
+                            startActivity(intent)
                             true
                         }
                         else -> false

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFollowerFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFollowerFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentRankFollowerBinding
+import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.ui.rank.adapter.RankFollowerAdapter
 import kr.co.lion.unipiece.ui.rank.adapter.RankPieceAdapter
@@ -25,7 +26,8 @@ class RankFollowerFragment : Fragment() {
     val adapter: RankFollowerAdapter by lazy {
         RankFollowerAdapter(testAuthorList,
             itemClickListener = { testId ->
-                Log.d("test", testId.toString())
+                val intent = Intent(requireActivity(), AuthorInfoActivity::class.java)
+                startActivity(intent)
             })
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankSaleFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankSaleFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.rank
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentRankSaleBinding
+import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
 import kr.co.lion.unipiece.ui.rank.adapter.RankSaleAdapter
 
 class RankSaleFragment : Fragment() {
@@ -22,7 +24,8 @@ class RankSaleFragment : Fragment() {
     val adapter: RankSaleAdapter by lazy {
         RankSaleAdapter(testAuthorList,
             itemClickListener = {testId ->
-                Log.d("test", testId.toString())
+                val intent = Intent(requireActivity(), AuthorInfoActivity::class.java)
+                startActivity(intent)
             })
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.search
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentSearchBinding
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.util.hideSoftInput
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -32,6 +34,7 @@ class SearchFragment : Fragment() {
 
     fun settingToolbarSearch(){
         with(binding.toolbarSearch) {
+
             setNavigationOnClickListener {
                 activity?.onBackPressed()
                 activity?.onBackPressed()
@@ -41,7 +44,8 @@ class SearchFragment : Fragment() {
             setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
                     R.id.menu_cart -> {
-
+                        val intent = Intent(requireActivity(), CartActivity::class.java)
+                        startActivity(intent)
                         true
                     }
                     else -> false

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
@@ -11,6 +11,8 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentSearchResultBinding
+import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
+import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.ui.search.adapter.SearchAuthorData
 import kr.co.lion.unipiece.ui.search.adapter.SearchPieceData
@@ -28,8 +30,8 @@ class SearchResultFragment : Fragment() {
 
     val searchAdpater: SearchResultAdapter by lazy {
         SearchResultAdapter(
-            itemClickListener = {test ->
-                Log.d("test", test.toString())
+            itemClickListener = {data ->
+                moveToPage(data.viewType)
             }
         )
     }
@@ -119,6 +121,17 @@ class SearchResultFragment : Fragment() {
 
         for(i in 0 until 10){
             testList.add(SearchResultData(SearchAuthorData(), SearchPieceData(), PIECE_CONTENT))
+        }
+    }
+
+    fun moveToPage(viewType: SearchResultViewType) {
+        if(viewType == PIECE_CONTENT){
+            val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+            startActivity(intent)
+        }
+        if(viewType == AUTHOR_CONTENT){
+            val intent = Intent(requireActivity(), AuthorInfoActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.search
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
@@ -10,6 +11,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentSearchResultBinding
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.ui.search.adapter.SearchAuthorData
 import kr.co.lion.unipiece.ui.search.adapter.SearchPieceData
 import kr.co.lion.unipiece.ui.search.adapter.SearchResultAdapter
@@ -80,7 +82,8 @@ class SearchResultFragment : Fragment() {
             setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
                     R.id.menu_cart -> {
-
+                        val intent = Intent(requireActivity(), CartActivity::class.java)
+                        startActivity(intent)
                         true
                     }
                     else -> false

--- a/app/src/main/res/layout/activity_buy_detail.xml
+++ b/app/src/main/res/layout/activity_buy_detail.xml
@@ -314,7 +314,7 @@
             app:tint="@color/third"/>
 
         <ImageView
-            android:id="@+id/shopBtn"
+            android:id="@+id/cartBtn"
             android:layout_width="30dp"
             android:layout_height="30dp"
             android:src="@drawable/shopcart_icon"


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Feature] 작품 구매 및 랭킹 화면 이동 #89

## 📝작업 내용

> 작품구매 화면에서 장바구니 이동(CartActivity)
  검색화면에서 장바구니 이동(CartActivity)
  검색결과 화면에서 작가 상세보기 화면 이동 (AuthorInfoActvity)
  검색결과 화면에서 작품 상세보기 화면 이동(BuyDetailActivity)
  작품 구매 상세보기 화면에서 장바구니 이동(CartActivity)
  작품 구매 상세보기 화면에서 구매 화면 이동 (OrderActivity)
  작가 랭킹 화면에서 작가 상세보기 화면 이동 (AuthorInfoActvity)
