### PR TITLE
[#86] feature 나의 갤러리 화면 이동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/MyGalleryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/MyGalleryFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.mygallery
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -11,6 +12,7 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentMyGalleryBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.mygallery.adapter.MyGalleryViewPagerAdapter
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.util.setMenuIconColor
 
 class MyGalleryFragment : Fragment() {
@@ -53,6 +55,16 @@ class MyGalleryFragment : Fragment() {
         binding.apply {
             toolbarMyGallery.apply {
                 inflateMenu(R.menu.menu_cart)
+                setOnMenuItemClickListener {
+                    when(it.itemId) {
+                        R.id.menu_cart -> {
+                            val intent = Intent(requireActivity(), CartActivity::class.java)
+                            startActivity(intent)
+                        }
+                    }
+
+                    true
+                }
 
                 requireContext().setMenuIconColor(menu, R.id.menu_cart, R.color.second)
             }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchaseCancelFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchaseCancelFragment.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentPurchaseCancelBinding
-import kr.co.lion.unipiece.databinding.FragmentPurchasedPieceDetailBinding
+import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.PurchasedPieceDetailFragmentName
 
 class PurchaseCancelFragment : Fragment() {
@@ -28,6 +28,7 @@ class PurchaseCancelFragment : Fragment() {
 
         settingToolbar()
         settingTextFieldPurchaseCancelReason()
+        settingButtonPurchaseCancel()
 
         return binding.root
     }
@@ -65,5 +66,24 @@ class PurchaseCancelFragment : Fragment() {
             }
         }
         materialAlertDialogBuilder.show()
+    }
+
+    fun settingButtonPurchaseCancel() {
+        binding.apply {
+            buttonPurchaseCancel.setOnClickListener {
+                val dialog = CustomDialog("주문 취소", "취소하면 되돌일 수 없습니다.\n취소하시겠습니까?")
+
+                dialog.setButtonClickListener(object: CustomDialog.OnButtonClickListener{
+                    override fun okButtonClick() {
+                        purchasedPieceDetailActivity.removeFragment(PurchasedPieceDetailFragmentName.PURCHASE_CANCEL_FRAGEMNT)
+                    }
+
+                    override fun noButtonClick() {
+                    }
+                })
+
+                dialog.show(purchasedPieceDetailActivity.supportFragmentManager, "CustomDialog")
+            }
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.mygallery
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -8,6 +9,11 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentPurchasedPieceDetailBinding
+import kr.co.lion.unipiece.ui.MainActivity
+import kr.co.lion.unipiece.ui.home.HomeFragment
+import kr.co.lion.unipiece.ui.payment.cart.CartActivity
+import kr.co.lion.unipiece.ui.search.SearchFragment
+import kr.co.lion.unipiece.util.MainFragmentName
 import kr.co.lion.unipiece.util.PurchasedPieceDetailFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -39,6 +45,17 @@ class PurchasedPieceDetailFragment : Fragment() {
                 }
 
                 inflateMenu(R.menu.menu_home)
+                setOnMenuItemClickListener {
+                    when(it.itemId) {
+                        R.id.menu_home -> {
+                            val intent = Intent(requireActivity(), MainActivity::class.java)
+                            purchasedPieceDetailActivity.finish()
+                            startActivity(intent)
+                        }
+                    }
+
+                    true
+                }
 
                 requireContext().setMenuIconColor(menu, R.id.menu_home, R.color.second)
             }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
@@ -49,8 +49,8 @@ class PurchasedPieceDetailFragment : Fragment() {
                     when(it.itemId) {
                         R.id.menu_home -> {
                             val intent = Intent(requireActivity(), MainActivity::class.java)
-                            purchasedPieceDetailActivity.finish()
                             startActivity(intent)
+                            requireActivity().finish()
                         }
                     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/RefundFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/RefundFragment.kt
@@ -8,8 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kr.co.lion.unipiece.R
-import kr.co.lion.unipiece.databinding.FragmentPurchasedPieceDetailBinding
 import kr.co.lion.unipiece.databinding.FragmentRefundBinding
+import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.PurchasedPieceDetailFragmentName
 
 class RefundFragment : Fragment() {
@@ -28,6 +28,7 @@ class RefundFragment : Fragment() {
 
         settingToolbar()
         settingTextFieldRefundReason()
+        settingButtonRefund()
 
         return binding.root
     }
@@ -65,5 +66,24 @@ class RefundFragment : Fragment() {
             }
         }
         materialAlertDialogBuilder.show()
+    }
+
+    fun settingButtonRefund() {
+        binding.apply {
+            buttonRefund.setOnClickListener {
+                val dialog = CustomDialog("반품 접수", "반품 접수 신청 시 되돌릴 수 없습니다.\n접수하시겠습니까?\n\n※ 반품 접수 승인 완료까지 1~2일 소요됩니다.")
+
+                dialog.setButtonClickListener(object: CustomDialog.OnButtonClickListener{
+                    override fun okButtonClick() {
+                        purchasedPieceDetailActivity.removeFragment(PurchasedPieceDetailFragmentName.REFUND_FRAGMENT)
+                    }
+
+                    override fun noButtonClick() {
+                    }
+                })
+
+                dialog.show(purchasedPieceDetailActivity.supportFragmentManager, "CustomDialog")
+            }
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
@@ -17,6 +17,7 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentSalePieceBinding
 import kr.co.lion.unipiece.databinding.RowSalePieceBinding
 import kr.co.lion.unipiece.ui.MainActivity
+import kr.co.lion.unipiece.ui.author.AddAuthorActivity
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.ui.mygallery.adapter.SalePieceAdapter
 
@@ -32,7 +33,7 @@ class SalePieceFragment : Fragment() {
         }
     }
 
-    var isArtist = true
+    var isArtist = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentSalePieceBinding.inflate(inflater, container, false)
@@ -50,6 +51,7 @@ class SalePieceFragment : Fragment() {
                 settingButtonSalePieceAddPiece()
             } else {
                 layoutArtist.isVisible = false
+                settingButtonSalePieceAddArtist()
             }
         }
     }
@@ -58,6 +60,15 @@ class SalePieceFragment : Fragment() {
         binding.apply {
             buttonSalePieceAddPiece.setOnClickListener {
                 val intent = Intent(requireActivity(), SalesApplicationActivity::class.java)
+                startActivity(intent)
+            }
+        }
+    }
+
+    fun settingButtonSalePieceAddArtist() {
+        binding.apply {
+            buttonSalePieceAddArtist.setOnClickListener {
+                val intent = Intent(requireActivity(), AddAuthorActivity::class.java)
                 startActivity(intent)
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
@@ -26,7 +26,9 @@ class SalePieceFragment : Fragment() {
 
     val salePieceAdapter: SalePieceAdapter by lazy {
         SalePieceAdapter { position ->
-            Snackbar.make(requireView(), "${position}번째 항목", Snackbar.LENGTH_SHORT).show()
+            val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
+            intent.putExtra("MyGalleryFragment", true)
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
@@ -33,7 +33,7 @@ class SalePieceFragment : Fragment() {
         }
     }
 
-    var isArtist = false
+    var isArtist = true
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentSalePieceBinding.inflate(inflater, container, false)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalePieceFragment.kt
@@ -38,7 +38,6 @@ class SalePieceFragment : Fragment() {
         binding = FragmentSalePieceBinding.inflate(inflater, container, false)
 
         initView()
-        settingButtonSalePieceAddPiece()
 
         return binding.root
     }
@@ -48,6 +47,7 @@ class SalePieceFragment : Fragment() {
             if(isArtist) {
                 layoutNotArtist.isVisible = false
                 settingRecyclerView()
+                settingButtonSalePieceAddPiece()
             } else {
                 layoutArtist.isVisible = false
             }
@@ -57,7 +57,8 @@ class SalePieceFragment : Fragment() {
     fun settingButtonSalePieceAddPiece() {
         binding.apply {
             buttonSalePieceAddPiece.setOnClickListener {
-                startActivity(Intent(requireActivity(), SalesApplicationActivity::class.java))
+                val intent = Intent(requireActivity(), SalesApplicationActivity::class.java)
+                startActivity(intent)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalesApplicationActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/SalesApplicationActivity.kt
@@ -13,6 +13,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivitySalesApplicationBinding
 import kr.co.lion.unipiece.databinding.CategoryDialogBinding
+import kr.co.lion.unipiece.databinding.DialogCustomBinding
+import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.hideSoftInput
 import kr.co.lion.unipiece.util.isKeyboardVisible
 import kr.co.lion.unipiece.util.showSoftInput
@@ -20,6 +22,7 @@ import kr.co.lion.unipiece.util.showSoftInput
 class SalesApplicationActivity : AppCompatActivity() {
 
     lateinit var binding: ActivitySalesApplicationBinding
+    lateinit var dialogCustomBinding: DialogCustomBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -68,6 +71,19 @@ class SalesApplicationActivity : AppCompatActivity() {
                     this@SalesApplicationActivity.hideSoftInput()
                     showDatePickerDialog()
                     true
+                }
+            }
+
+            buttonSalesApplicationSubmit.setOnClickListener {
+                MaterialAlertDialogBuilder(this@SalesApplicationActivity, R.style.Theme_Category_App_MaterialAlertDialog).apply {
+                    setTitle("작품 등록 신청 완료")
+                    setMessage("작품 등록 신청이 완료되었습니다.\n작품 등록 완료 시까지 1~2일 정도 소요됩니다.")
+
+                    setPositiveButton("확인") { dialogInterface: DialogInterface, i: Int ->
+                        finish()
+                    }
+
+                    show()
                 }
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/adapter/SalePieceAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/adapter/SalePieceAdapter.kt
@@ -1,9 +1,12 @@
 package kr.co.lion.unipiece.ui.mygallery.adapter
 
+import android.content.Context
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.databinding.RowSalePieceBinding
+import kr.co.lion.unipiece.ui.mygallery.SalesApplicationActivity
 
 class SalePieceAdapter (private val onItemClick: (position: Int) -> Unit): RecyclerView.Adapter<SalePieceViewHolderClass>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SalePieceViewHolderClass {
@@ -17,7 +20,7 @@ class SalePieceAdapter (private val onItemClick: (position: Int) -> Unit): Recyc
     }
 
     override fun onBindViewHolder(holder: SalePieceViewHolderClass, position: Int) {
-        holder.bind(position)
+        holder.bind(holder.itemView.context, position)
     }
 }
 
@@ -37,7 +40,11 @@ class SalePieceViewHolderClass(private val binding: RowSalePieceBinding, onItemC
 
     }
 
-    fun bind(position: Int) {
+    fun bind(context: Context, position: Int) {
         binding.textViewRowSalePieceName.text = "$position"
+        binding.buttonRowSalePieceModify.setOnClickListener {
+            val intent = Intent(context, SalesApplicationActivity::class.java)
+            context.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/res/layout/row_sale_piece.xml
+++ b/app/src/main/res/layout/row_sale_piece.xml
@@ -71,7 +71,7 @@
                 </LinearLayout>
 
                 <Button
-                    android:id="@+id/button"
+                    android:id="@+id/buttonRowSalePieceModify"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="23dp"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -49,6 +49,7 @@
         <item name="colorPrimary">@color/first</item>
         <item name="colorSecondary">@color/second</item>
         <item name="android:background">@color/white</item>
+        <item name="android:fontFamily">@font/pretendard_regular</item>
     </style>
 
     <!-- 작품 등록 신청 DatePicker 설정 -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -56,6 +56,7 @@
     <style name="Theme.App.DatePicker" parent="@style/ThemeOverlay.Material3.MaterialCalendar">
         <item name="colorPrimary">@color/first</item>
         <item name="android:background">@color/white</item>
+        <item name="android:fontFamily">@font/pretendard_regular</item>
     </style>
 
     <!-- 작품 등록 신청 Category CardView 설정 -->


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #86 [feature] 나의 갤러리 화면 이동

## 📝작업 내용

>  toolbar 메뉴 : 홈(HomeFragment) / 장바구니(CartActivity)
 판매 작품(작가) : 작품 상세보기(BuyDetailActivity)
 판매 작품(작가) : 작품 등록 신청 수정(SalesApplicationActivity) / 작품 등록 신청(SalesApplicationActivity)
 판매 작품(일반) : 작가 등록 신청(AddAuthorActivity)
 판매 신청 완료 : 판매 작품(SalePieceFragment)
 주문 취소 완료 및 반품 신청 완료 : 다이얼로그 + 구매한 작품 상세보기(PurchasedPieceDetailFragment)

## 💬리뷰 요구사항(선택)

> 구매한 작품 상세보기의 toolbar 홈 메뉴를 클릭해서 홈으로 이동한 후에 백버튼을 누르면 홈에서 나의갤러리로 이동하는 이슈가 있습니다