### PR TITLE
[#91] 회원정보 전시실 방문 작가 상세보기 화면 이동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -52,7 +52,7 @@ class AuthorInfoFragment : Fragment() {
 
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
-                    authorInfoActivity.finish()
+                    requireActivity().finish()
                 }
 
                 // 회원 유형에 따라 메뉴 아이콘 다르게 표시
@@ -72,7 +72,7 @@ class AuthorInfoFragment : Fragment() {
                             authorInfoActivity.replaceFragment(AuthorInfoFragmentName.MODIFY_AUTHOR_INFO_FRAGMENT, true, modifyBundle)
                         }
                         R.id.menu_home -> {
-                            authorInfoActivity.finish()
+                            requireActivity().finish()
                         }
                     }
                     true

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -1,21 +1,19 @@
 package kr.co.lion.unipiece.ui.author
 
-import android.graphics.Color
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Space
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.core.view.marginRight
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
 import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
+import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -182,6 +180,11 @@ class AuthorInfoFragment : Fragment() {
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             // 이미지
             holder.rowAuthorPiecesBinding.imageViewAuthorPiece.setImageResource(R.drawable.ic_launcher_background)
+            // 작품 클릭 시 설명 화면 이동
+            holder.rowAuthorPiecesBinding.root.setOnClickListener {
+                val pieceIntent = Intent(requireActivity(), BuyDetailActivity::class.java)
+                startActivity(pieceIntent)
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
@@ -2,14 +2,11 @@ package kr.co.lion.unipiece.ui.author
 
 import android.content.Intent
 import android.os.Bundle
-import android.provider.MediaStore
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.result.ActivityResultLauncher
 import kr.co.lion.unipiece.R
-import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
 import kr.co.lion.unipiece.databinding.FragmentModifyAuthorInfoBinding
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 
@@ -58,8 +55,9 @@ class ModifyAuthorInfoFragment : Fragment() {
     // 작가 갱신 버튼
     private fun settingButtonUpdateAuthor(){
         fragmentModifyAuthorInfoBinding.buttonModifyAuthorUpdateAuthor.setOnClickListener {
-            // 추후 수정
-            authorInfoActivity.removeFragment(AuthorInfoFragmentName.MODIFY_AUTHOR_INFO_FRAGMENT)
+            // 작가 갱신 액티비티로 이동
+            val updateAuthorIntent = Intent(requireActivity(), UpdateAuthorActivity::class.java)
+            startActivity(updateAuthorIntent)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ApplyVisitGalleryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ApplyVisitGalleryFragment.kt
@@ -15,7 +15,10 @@ class ApplyVisitGalleryFragment : Fragment() {
     lateinit var fragmentApplyVisitGalleryBinding: FragmentApplyVisitGalleryBinding
     lateinit var visitGalleryActivity: VisitGalleryActivity
 
-    override fun onCreateView(
+    // 신청 수정 여부
+    private var isModify = false
+
+        override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
@@ -33,9 +36,16 @@ class ApplyVisitGalleryFragment : Fragment() {
 
     // 툴바 셋팅
     private fun settingToolbar(){
+        isModify = requireArguments().getBoolean("isModify", false)
+
         fragmentApplyVisitGalleryBinding.apply {
             toolbarApplyVisitGallery.apply {
-                title = "전시실 방문 신청"
+
+                title = if(isModify){
+                    "전시실 방문 신청 수정"
+                }else{
+                    "전시실 방문 신청"
+                }
 
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentModifyUserInfoBinding
 import kr.co.lion.unipiece.ui.login.LoginActivity
+import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 
 class ModifyUserInfoFragment : Fragment() {
@@ -70,13 +71,25 @@ class ModifyUserInfoFragment : Fragment() {
         fragmentModifyUserInfoBinding.buttonDeleteUser.apply {
             setOnClickListener {
                 // 회원 탈퇴 확인 다이얼로그
+                val dialog = CustomDialog("회원 탈퇴", "회원 탈퇴 시 되돌릴 수 없습니다. \n탈퇴하시겠습니까?")
 
-                // 회원 탈퇴 처리
+                dialog.setButtonClickListener(object: CustomDialog.OnButtonClickListener{
+                    override fun okButtonClick() {
+                        // 회원 탈퇴 처리
 
-                // 로그인 화면으로 이동
-                val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
-                loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                startActivity(loginIntent)
+                        // 로그인 화면으로 이동
+                        val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
+                        loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        startActivity(loginIntent)
+                    }
+
+                    override fun noButtonClick() {
+                    }
+
+                })
+
+                dialog.show(requireActivity().supportFragmentManager, "DeleteUser")
+
             }
 
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.mypage
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -7,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentModifyUserInfoBinding
+import kr.co.lion.unipiece.ui.login.LoginActivity
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 
 class ModifyUserInfoFragment : Fragment() {
@@ -66,17 +68,16 @@ class ModifyUserInfoFragment : Fragment() {
     // 회원 탈퇴 버튼
     private fun settingButtonDeleteUser(){
         fragmentModifyUserInfoBinding.buttonDeleteUser.apply {
-
-            // 추후 제거
             setOnClickListener {
-                userInfoActivity.removeFragment(UserInfoFragmentName.MODIFY_USER_INFO_FRAGMENT)
-            }
+                // 회원 탈퇴 확인 다이얼로그
 
-            // 회원 탈퇴 확인 다이얼로그
-            
-            // 회원 탈퇴 처리
-            
-            // 로그인 화면으로 이동
+                // 회원 탈퇴 처리
+
+                // 로그인 화면으로 이동
+                requireActivity().finish()
+                val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
+                startActivity(loginIntent)
+            }
 
         }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -74,8 +74,8 @@ class ModifyUserInfoFragment : Fragment() {
                 // 회원 탈퇴 처리
 
                 // 로그인 화면으로 이동
-                requireActivity().finish()
                 val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
+                loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
                 startActivity(loginIntent)
             }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentUserInfoBinding
 import kr.co.lion.unipiece.ui.payment.delivery.DeliveryActivity
+import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -44,6 +45,16 @@ class UserInfoFragment : Fragment() {
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
                     userInfoActivity.finish()
+                }
+
+                // 툴바 메뉴 클릭 이벤트
+                setOnMenuItemClickListener {
+                    when(it.itemId){
+                        R.id.menu_home -> {
+                            userInfoActivity.finish()
+                        }
+                    }
+                    true
                 }
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.mypage
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -7,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentUserInfoBinding
+import kr.co.lion.unipiece.ui.payment.delivery.DeliveryActivity
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -67,8 +69,9 @@ class UserInfoFragment : Fragment() {
         fragmentUserInfoBinding.buttonManageAddress.apply {
             setOnClickListener {
                 // 추후 전달할 데이터는 여기에 담기
-
+                val deliveryIntent = Intent(requireActivity(), DeliveryActivity::class.java)
                 // 배송지 관리 액티비티 실행
+                startActivity(deliveryIntent)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/UserInfoFragment.kt
@@ -44,14 +44,14 @@ class UserInfoFragment : Fragment() {
 
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
-                    userInfoActivity.finish()
+                    requireActivity().finish()
                 }
 
                 // 툴바 메뉴 클릭 이벤트
                 setOnMenuItemClickListener {
                     when(it.itemId){
                         R.id.menu_home -> {
-                            userInfoActivity.finish()
+                            requireActivity().finish()
                         }
                     }
                     true

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
@@ -12,6 +12,7 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentVisitGalleryHistoryBinding
 import kr.co.lion.unipiece.databinding.RowVisitGalleryHistoryBinding
+import kr.co.lion.unipiece.util.UserInfoFragmentName
 import kr.co.lion.unipiece.util.VisitGalleryFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
@@ -124,6 +125,15 @@ class VisitGalleryHistoryFragment : Fragment() {
             holder.rowVisitGalleryHistoryBinding.textViewRowVisitListStatus.text="승인 대기중"
             // 신청 수정 버튼 여부
             holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.isVisible = true
+
+            // 신청 수정 버튼 클릭 이벤트
+            holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.setOnClickListener {
+                // 추후 전달할 데이터는 여기에 담기
+                val modifyBundle = Bundle()
+                modifyBundle.putBoolean("isModify", true)
+                // 회원 정보 수정 프래그먼트 교체
+                visitGalleryActivity.replaceFragment(VisitGalleryFragmentName.APPLY_VISIT_GALLERY_FRAGMENT,true, modifyBundle)
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
@@ -48,7 +48,7 @@ class VisitGalleryHistoryFragment : Fragment() {
                 setOnMenuItemClickListener {
                     when(it.itemId){
                         R.id.menu_home -> {
-                            visitGalleryActivity.finish()
+                            requireActivity().finish()
                         }
                     }
                     true
@@ -56,7 +56,7 @@ class VisitGalleryHistoryFragment : Fragment() {
 
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
-                    visitGalleryActivity.finish()
+                    requireActivity().finish()
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91 

## 📝작업 내용

> 화면 이동 작업
회원 정보 화면에서 배송지 관리 화면 이동 (DeliveryActivity)
(배송지 관리에서 뒤로가기 아이콘 누르면 이전 액티비티로 돌아가게 수정 필요)
전시실 방문 신청 목록에서 전시실 방문 신청 수정 화면 이동 (VisitGalleryActivity)
작가 상세보기 화면에서 작품 설명 화면 이동 (BuyDetailActivity)
작가 정보 수정 화면에서 작가 갱신 화면 이동 (UpdateAuthorActivity)
 회원탈퇴 (LoginActivity)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
