### PR TITLE
[#104] 화면 이동 관련 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -36,7 +36,8 @@ class MainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         // 새로운 Intent를 현재 Intent로 설정
         setIntent(intent)
-        // 필요한 경우 여기서 openSearchFragment()를 호출할 수도 있습니다.
+
+        // 새로운 intent로 새로운 fragment들로 화면 설정
         openSearchFragment()
         openHomeFragment()
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -30,7 +30,6 @@ class MainActivity : AppCompatActivity() {
         bottomNaviClick()
         initView()
         setBuyNaviDrawer()
-        // openSearchFragment()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -39,6 +38,7 @@ class MainActivity : AppCompatActivity() {
         setIntent(intent)
         // 필요한 경우 여기서 openSearchFragment()를 호출할 수도 있습니다.
         openSearchFragment()
+        openHomeFragment()
     }
 
 
@@ -292,6 +292,17 @@ class MainActivity : AppCompatActivity() {
         if (isSearchFragment) {
             replaceFragment(SEARCH_FRAGMENT, true)
         }
+    }
 
+    fun openHomeFragment() {
+        val isHomeFragment = intent.getBooleanExtra(HOME_FRAGMENT.str, false)
+        // HomeFragment가 true인 경우 프래그먼트 변경 로직을 실행합니다.
+        if (isHomeFragment) {
+            // backStack을 비워준다.
+            supportFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+
+            // MainActivity가 이미 실행 중인 경우 해당 인스턴스를 재사용합니다.
+            binding.bottomNavigationView.selectedItemId = R.id.fragment_home
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.SystemClock
@@ -29,8 +30,17 @@ class MainActivity : AppCompatActivity() {
         bottomNaviClick()
         initView()
         setBuyNaviDrawer()
+        // openSearchFragment()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // 새로운 Intent를 현재 Intent로 설정
+        setIntent(intent)
+        // 필요한 경우 여기서 openSearchFragment()를 호출할 수도 있습니다.
         openSearchFragment()
     }
+
 
     fun printFragmentBackStack(name: String) {
         val fragmentManager = supportFragmentManager
@@ -134,13 +144,17 @@ class MainActivity : AppCompatActivity() {
             if(drawerBuyLayout.isDrawerOpen(GravityCompat.START)){
                 drawerBuyLayout.close()
             } else {
+                super.onBackPressed()
+                updateBottomNavi()
+
                 var isSearchFragmentOnTop = false
 
                 if (supportFragmentManager.backStackEntryCount > 0) {
                     // 백 스택의 마지막 항목의 이름을 가져옵니다.
                     val lastFragmentName = supportFragmentManager.getBackStackEntryAt(supportFragmentManager.backStackEntryCount - 1).name
                     // 마지막 항목의 이름이 "SearchFragment"와 일치하는지 확인합니다.
-                    isSearchFragmentOnTop = "SearchFragment" == lastFragmentName
+                    isSearchFragmentOnTop = SEARCH_FRAGMENT.str == lastFragmentName || "SearchResultFragment" == lastFragmentName
+
                 } else {
                     // 백 스택이 비어있으면, SearchFragment가 최상단에 있을 수 없습니다.
                     isSearchFragmentOnTop = false
@@ -151,11 +165,6 @@ class MainActivity : AppCompatActivity() {
                     // 안드로이드 뒤로가기 버튼 실행 -> searchresultfragment에서 뒤로갔을때 searchfragment로 가지 않고 그 전으로 가기
                     printFragmentBackStack("two back")
                     super.onBackPressed()
-                    super.onBackPressed()
-                } else {
-                    // 안드로이드 뒤로가기 버튼 실행
-                    printFragmentBackStack("one back")
-                    super.onBackPressed()
                 }
 
                 // Fragment BackStack에 아무것도 남아있지 않을 때 activity 종료
@@ -163,7 +172,6 @@ class MainActivity : AppCompatActivity() {
                     finish()
                 }
 
-                updateBottomNavi()
             }
         }
     }
@@ -279,29 +287,11 @@ class MainActivity : AppCompatActivity() {
 
     fun openSearchFragment() {
 
-        val isRankFragment = intent.getBooleanExtra(RANK_FRAGMENT.str, false)
-        val isBuyFragment = intent.getBooleanExtra(BUY_FRAGMENT.str, false)
-        val isMyGalleryFragment = intent.getBooleanExtra(MY_GALLERY_FRAGMENT.str, false)
         val isSearchFragment = intent.getBooleanExtra(SEARCH_FRAGMENT.str, false)
-
-        // RANK_FRAGMENT 또는 BUY_FRAGMENT 또는 MY_GALLERY가 true인 경우에만 로직을 실행합니다.
-        if (isRankFragment || isBuyFragment || isMyGalleryFragment) {
-
-            // 선택된 탭을 설정합니다.
-             if (isRankFragment) {
-                binding.bottomNavigationView.selectedItemId = R.id.fragment_rank
-            } else if (isBuyFragment) {
-                 binding.bottomNavigationView.selectedItemId = R.id.fragment_buy
-            } else {
-                binding.bottomNavigationView.selectedItemId = R.id.fragment_mygallery
-             }
-
-            // SearchFragment가 true인 경우 프래그먼트 변경 로직을 실행합니다.
-            if (isSearchFragment) {
-                supportFragmentManager.popBackStack()
-                supportFragmentManager.popBackStack()
-                replaceFragment(SEARCH_FRAGMENT, true)
-            }
+        // SearchFragment가 true인 경우 프래그먼트 변경 로직을 실행합니다.
+        if (isSearchFragment) {
+            replaceFragment(SEARCH_FRAGMENT, true)
         }
+
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyDetailActivity.kt
@@ -59,15 +59,11 @@ class BuyDetailActivity : AppCompatActivity() {
     }
 
     fun setIntent(name: String) {
-        val buyIntent = intent.getBooleanExtra(BUY_FRAGMENT.str, false)
-        val rankIntent = intent.getBooleanExtra(RANK_FRAGMENT.str, false)
-        val mygalleryIntent = intent.getBooleanExtra(MY_GALLERY_FRAGMENT.str, false)
 
-        val intent = Intent(this@BuyDetailActivity, MainActivity::class.java)
-        intent.putExtra("RankFragment", rankIntent)
-        intent.putExtra("BuyFragment", buyIntent)
-        intent.putExtra("MyGalleryFragment", mygalleryIntent)
-
+        val intent = Intent(this@BuyDetailActivity, MainActivity::class.java).apply {
+            // MainActivity가 이미 실행 중인 경우 해당 인스턴스를 재사용합니다.
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
         intent.putExtra(name, true)
         startActivity(intent)
         finish()

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -55,8 +55,8 @@ class BuyFragment : Fragment() {
                 setOnMenuItemClickListener { menuItem ->
                     when (menuItem.itemId) {
                         R.id.menu_search -> {
-                            val fragmentManager = activity?.supportFragmentManager?.beginTransaction()
-                            fragmentManager?.replace(R.id.fl_container, SearchFragment())?.addToBackStack(null)?.commit()
+                            val fragmentManager = parentFragmentManager.beginTransaction()
+                            fragmentManager.replace(R.id.fl_container, SearchFragment()).addToBackStack("SearchFragment").commit()
                             true
                         }
                         R.id.menu_cart -> {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
@@ -43,7 +43,6 @@ class BuyNewFragment : Fragment() {
         adapter = BuyNewAdapter(testImageList,
             itemClickListener = { testReviewId ->
                 val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
-                intent.putExtra("BuyFragment", true)
                 startActivity(intent)
             }
         )

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
@@ -39,7 +39,6 @@ class BuyPopFragment : Fragment() {
         adapter = BuyPopAdapter(testImageList,
             itemClickListener = { testReviewId ->
                 val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
-                intent.putExtra("BuyFragment", true)
                 startActivity(intent)
             }
         )

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
@@ -47,8 +47,7 @@ class PurchasedPieceDetailFragment : Fragment() {
                     when(it.itemId) {
                         R.id.menu_home -> {
                             val intent = Intent(requireActivity(), MainActivity::class.java)
-                                .apply{
-                                 //
+                                .apply{ // MainActivity가 이미 실행 중인 경우 해당 인스턴스를 재사용합니다.
                                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                             }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
@@ -47,8 +47,14 @@ class PurchasedPieceDetailFragment : Fragment() {
                     when(it.itemId) {
                         R.id.menu_home -> {
                             val intent = Intent(requireActivity(), MainActivity::class.java)
-                            startActivity(intent)
+                                .apply{
+                                 //
+                                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                            }
+
+                            intent.putExtra("HomeFragment", true)
                             requireActivity().finish()
+                            startActivity(intent)
                         }
                     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mygallery/PurchasedPieceDetailFragment.kt
@@ -20,12 +20,10 @@ import kr.co.lion.unipiece.util.setMenuIconColor
 class PurchasedPieceDetailFragment : Fragment() {
 
     lateinit var binding: FragmentPurchasedPieceDetailBinding
-    lateinit var purchasedPieceDetailActivity: PurchasedPieceDetailActivity
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         binding = FragmentPurchasedPieceDetailBinding.inflate(inflater, container, false)
-        purchasedPieceDetailActivity = activity as PurchasedPieceDetailActivity
 
         settingToolbar()
         settingRefundApprovalView()
@@ -41,7 +39,7 @@ class PurchasedPieceDetailFragment : Fragment() {
 
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
-                    purchasedPieceDetailActivity.finish()
+                    requireActivity().finish()
                 }
 
                 inflateMenu(R.menu.menu_home)
@@ -70,13 +68,18 @@ class PurchasedPieceDetailFragment : Fragment() {
     }
 
     fun settingButtons() {
+        val supportFragmentManager = parentFragmentManager.beginTransaction()
         binding.apply {
             buttonPurchasedPieceDetailOrderCancel.setOnClickListener {
-                purchasedPieceDetailActivity.replaceFragment(PurchasedPieceDetailFragmentName.PURCHASE_CANCEL_FRAGEMNT, true)
+            supportFragmentManager.replace(R.id.containerPurchasedPieceDetail, PurchaseCancelFragment())
+                .addToBackStack(PurchasedPieceDetailFragmentName.PURCHASE_CANCEL_FRAGEMNT.str)
+                .commit()
             }
 
             buttonPurchasedPieceDetailRefund.setOnClickListener {
-                purchasedPieceDetailActivity.replaceFragment(PurchasedPieceDetailFragmentName.REFUND_FRAGMENT, true)
+                supportFragmentManager.replace(R.id.containerPurchasedPieceDetail, RefundFragment())
+                    .addToBackStack(PurchasedPieceDetailFragmentName.REFUND_FRAGMENT.str)
+                    .commit()
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -24,12 +24,10 @@ import kr.co.lion.unipiece.ui.payment.order.OrderActivity
 class OrderMainFragment : Fragment() {
 
     lateinit var fragmentOrderMainBinding: FragmentOrderMainBinding
-    lateinit var orderActivity: OrderActivity
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         fragmentOrderMainBinding = FragmentOrderMainBinding.inflate(layoutInflater)
-        orderActivity = activity as OrderActivity
         setToolbar()
         clickButtonDeliveryChange()
         setRecyclerViewCart()
@@ -73,7 +71,9 @@ class OrderMainFragment : Fragment() {
         fragmentOrderMainBinding.apply {
             buttonOrderPaymentSubmit.apply {
                 setOnClickListener {
-                    orderActivity.replaceFragment(OrderFragmentName.ORDER_SUCCESS_FRAGMENT,false)
+                    parentFragmentManager.beginTransaction()
+                        .replace(R.id.containerOrder, OrderSuccessFragment())
+                        .commit()
                     // 추후 수정
                 }
             }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -74,7 +74,6 @@ class OrderMainFragment : Fragment() {
             buttonOrderPaymentSubmit.apply {
                 setOnClickListener {
                     orderActivity.replaceFragment(OrderFragmentName.ORDER_SUCCESS_FRAGMENT,false)
-                    orderActivity.finish()
                     // 추후 수정
                 }
             }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankFragment.kt
@@ -48,7 +48,7 @@ class RankFragment : Fragment() {
                     when (menuItem.itemId) {
                         R.id.menu_search -> {
                             val fragmentManager = activity?.supportFragmentManager?.beginTransaction()
-                            fragmentManager?.replace(R.id.fl_container, SearchFragment())?.addToBackStack("RankFragment")?.commit()
+                            fragmentManager?.replace(R.id.fl_container, SearchFragment())?.addToBackStack("SearchFragment")?.commit()
                             true
                         }
                         else -> false
@@ -80,20 +80,19 @@ class RankFragment : Fragment() {
 
     private fun setFragment(name: RankFragmentName) {
 
-        val fragmentMananger = activity?.supportFragmentManager?.beginTransaction()
+        val fragmentMananger = parentFragmentManager.beginTransaction()
 
             when(name) {
                 RANK_PIECE_FRAGMENT -> {
-                    fragmentMananger?.replace(R.id.rank_fragment, RankPieceFragment())
+                    fragmentMananger.replace(R.id.rank_fragment, RankPieceFragment())
                     binding.rankTitle.text = "작품 랭킹"
                 }
                 RANK_AUTHOR_FRAGMENT -> {
-                    fragmentMananger?.replace(R.id.rank_fragment, RankAuthorFragment())
+                    fragmentMananger.replace(R.id.rank_fragment, RankAuthorFragment())
                     binding.rankTitle.text = "작가 랭킹"
                 }
             }
-        fragmentMananger?.addToBackStack(name.str)
-        fragmentMananger?.commit()
+        fragmentMananger.commit()
     }
 
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankPieceFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/rank/RankPieceFragment.kt
@@ -24,7 +24,6 @@ class RankPieceFragment : Fragment() {
         RankPieceAdapter(testPieceList,
             itemClickListener = { testId ->
                 val intent = Intent(requireActivity(), BuyDetailActivity::class.java)
-                intent.putExtra("RankFragment", true)
                 startActivity(intent)
             })
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchFragment.kt
@@ -36,8 +36,7 @@ class SearchFragment : Fragment() {
         with(binding.toolbarSearch) {
 
             setNavigationOnClickListener {
-                activity?.onBackPressed()
-                activity?.onBackPressed()
+               requireActivity().onBackPressed()
             }
 
             inflateMenu(R.menu.menu_cart)
@@ -61,8 +60,8 @@ class SearchFragment : Fragment() {
 
             searchBar.setOnEditorActionListener { textView, action, Event ->
                 if(action == EditorInfo.IME_ACTION_SEARCH){
-                    val fragmentManager = activity?.supportFragmentManager?.beginTransaction()
-                    fragmentManager?.replace(R.id.fl_container, SearchResultFragment())?.addToBackStack("SearchFragment")?.commit()
+                    val fragmentManager = parentFragmentManager.beginTransaction()
+                    fragmentManager.replace(R.id.fl_container, SearchResultFragment()).addToBackStack("SearchResultFragment").commit()
                     handled = true
                     requireActivity().hideSoftInput()
                 }
@@ -73,8 +72,8 @@ class SearchFragment : Fragment() {
                 if(event.action == MotionEvent.ACTION_UP) {
                     val touchArea = searchBar.right - searchBar.compoundDrawables[2].bounds.width() - 50
                     if(event.rawX >= touchArea) {
-                        val fragmentManager = activity?.supportFragmentManager?.beginTransaction()
-                        fragmentManager?.replace(R.id.fl_container, SearchResultFragment())?.addToBackStack("SearchFragment")?.commit()
+                        val fragmentManager = parentFragmentManager.beginTransaction()
+                        fragmentManager.replace(R.id.fl_container, SearchResultFragment()).addToBackStack("SearchResultFragment").commit()
                         requireActivity().hideSoftInput()
                         handled = true
                     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/search/SearchResultFragment.kt
@@ -56,28 +56,8 @@ class SearchResultFragment : Fragment() {
     fun settingToolbarSearchResult(){
         with(binding.toolbarSearchResult) {
             setNavigationOnClickListener {
-
-                val supportFragmentManager = activity?.supportFragmentManager
-
-                var isSearchFragmentOnTop = false
-                val count = supportFragmentManager?.backStackEntryCount ?: 0
-                if (count > 0) {
-                    // 백 스택의 마지막 항목의 이름을 가져옵니다.
-                    val lastFragmentName = activity?.supportFragmentManager?.getBackStackEntryAt(count - 1)?.name
-                    // 마지막 항목의 이름이 "SearchFragment"와 일치하는지 확인합니다.
-                    isSearchFragmentOnTop = "SearchFragment" == lastFragmentName
-                } else {
-                    // 백 스택이 비어있으면, SearchFragment가 최상단에 있을 수 없습니다.
-                    isSearchFragmentOnTop = false
-                }
-
-                if(isSearchFragmentOnTop) {
-                    activity?.onBackPressed()
-                    activity?.onBackPressed()
-                } else {
-                    activity?.onBackPressed()
-                }
-
+                parentFragmentManager.popBackStack()
+                activity?.onBackPressed()
             }
 
             inflateMenu(R.menu.menu_cart)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) [Fix] 화면 이동 관련 버그 #104

## 📝작업 내용

-  주문 화면에서 주문완료로 이동시 화면 바로 꺼지는 버그 수정
- 작품구매, 랭킹 화면에서 작품 상세보기로 이동 후 검색 창 이동하는 코드 수정
- PurchasePieceDetailFragment(구매 기록 상세보기) activity 참조 삭제 후 fragment 이동 코드 수정
- OrderMainFragment에서 activity 참조 삭제 후 fragment 이동 코드 수정
- PurchasePieceDetailFragment(구매 기록 상세보기)  홈 버튼 눌렀을 때 뒤로가기 눌렀을때 나의 갤러리로 이동하는 버그 수정
- Fragment에서 activity 사용하는 이동 코드 삭제
```kotlin
val fragmentMananger = activity?.supportFragmentManager?.beginTransaction() // 삭제
val fragmentMananger = parentFragmentManager.beginTransaction() // 추가
``` 
- 기타 주석 추가 및 수정



