### PR TITLE
[#125] 리사이클러뷰 어댑터 파일 분리 갤러리 방문 신청 UI 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -14,8 +14,10 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
 import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
 import kr.co.lion.unipiece.ui.MainActivity
+import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.ui.mypage.ModifyUserInfoFragment
+import kr.co.lion.unipiece.ui.mypage.adapter.VisitGalleryAdapter
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
@@ -23,7 +25,9 @@ import kr.co.lion.unipiece.util.setMenuIconColor
 class AuthorInfoFragment : Fragment() {
 
     lateinit var fragmentAuthorInfoBinding: FragmentAuthorInfoBinding
+    lateinit var authorPiecesAdapter: AuthorPiecesAdapter
 
+    // 작가 팔로우 여부
     var authorFollow = false
 
     override fun onCreateView(
@@ -37,9 +41,14 @@ class AuthorInfoFragment : Fragment() {
         initView()
         settingButtonFollow()
         settingButtonReview()
-        settingRecyclerView()
+
 
         return fragmentAuthorInfoBinding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        settingRecyclerView()
     }
 
     // 툴바 셋팅
@@ -112,11 +121,7 @@ class AuthorInfoFragment : Fragment() {
         changeFollowButton()
 
         fragmentAuthorInfoBinding.buttonAuthorFollow.setOnClickListener {
-            if(!authorFollow){
-                authorFollow = true
-            }else{
-                authorFollow = false
-            }
+            authorFollow = !authorFollow
             changeFollowButton()
         }
     }
@@ -150,53 +155,36 @@ class AuthorInfoFragment : Fragment() {
 
     // 리사이클러 뷰 셋팅
     private fun settingRecyclerView(){
+        // 테스트 데이터
+        val piecesList = arrayListOf<Int>(
+            R.drawable.ic_launcher_background,
+            R.drawable.ic_launcher_foreground,
+            R.drawable.ic_launcher_background,
+            R.drawable.ic_launcher_foreground,
+            R.drawable.ic_launcher_background,
+            R.drawable.ic_launcher_foreground,
+            R.drawable.ic_launcher_background,
+            R.drawable.ic_launcher_foreground,
+            R.drawable.ic_launcher_background,
+            R.drawable.ic_launcher_foreground,
+        )
+
+        // 리사이클러뷰 어댑터
+        authorPiecesAdapter = AuthorPiecesAdapter(piecesList){
+            val pieceIntent = Intent(requireActivity(), BuyDetailActivity::class.java)
+            startActivity(pieceIntent)
+        }
+
+        // 리사이클러뷰 셋팅
         fragmentAuthorInfoBinding.recyclerViewAuthorPieces.apply {
             // 어댑터
-            adapter = RecyclerViewAdapter()
+            adapter = authorPiecesAdapter
             // 레이아웃 매니저, 가로 방향 셋팅
             layoutManager = LinearLayoutManager(requireActivity(), RecyclerView.HORIZONTAL, false)
-            // 데코레이션
-            // val deco = MaterialDividerItemDecoration(authorInfoActivity, MaterialDividerItemDecoration.HORIZONTAL)
-            // addItemDecoration(deco)
         }
     }
 
-    // 작품 리사이클러 뷰 어댑터
-    inner class RecyclerViewAdapter : RecyclerView.Adapter<RecyclerViewAdapter.ViewHolder>(){
-        inner class ViewHolder(rowAuthorPiecesBinding: RowAuthorPiecesBinding):
-            RecyclerView.ViewHolder(rowAuthorPiecesBinding.root){
-            val rowAuthorPiecesBinding: RowAuthorPiecesBinding
 
-            init {
-                this.rowAuthorPiecesBinding = rowAuthorPiecesBinding
-
-                this.rowAuthorPiecesBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            val rowAuthorPiecesBinding = RowAuthorPiecesBinding.inflate(layoutInflater)
-            val viewHolder = ViewHolder(rowAuthorPiecesBinding)
-            return viewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 20
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            // 이미지
-            holder.rowAuthorPiecesBinding.imageViewAuthorPiece.setImageResource(R.drawable.ic_launcher_background)
-            // 작품 클릭 시 설명 화면 이동
-            holder.rowAuthorPiecesBinding.root.setOnClickListener {
-                val pieceIntent = Intent(requireActivity(), BuyDetailActivity::class.java)
-                startActivity(pieceIntent)
-            }
-        }
-    }
 
     // 프래그먼트 교체 메서드
     private fun replaceFragment(bundle: Bundle){

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -14,10 +14,13 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorReviewBottomSheetBinding
 import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
 import kr.co.lion.unipiece.databinding.RowAuthorReviewBottomSheetBinding
+import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
+import kr.co.lion.unipiece.ui.author.adapter.AuthorReviewAdapter
 
 class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
 
     lateinit var fragmentAuthorReviewBottomSheetBinding: FragmentAuthorReviewBottomSheetBinding
+    lateinit var reviewAdapter: AuthorReviewAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,18 +29,31 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
         // Inflate the layout for this fragment
         fragmentAuthorReviewBottomSheetBinding = FragmentAuthorReviewBottomSheetBinding.inflate(inflater)
 
-        settingRecyclerView()
         settingButtonAuthorReviewAdd()
         
         return fragmentAuthorReviewBottomSheetBinding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        settingRecyclerView()
+    }
+
 
     // 리사이클러 뷰 셋팅
     private fun settingRecyclerView(){
+        // 테스트 데이터
+        val reviewList = arrayListOf<Any>(
+            "test","test","test","test","test","test","test","test","test","test"
+        )
+
+        // 리사이클러뷰 어댑터
+        reviewAdapter = AuthorReviewAdapter(reviewList)
+
+        // 리사이클러뷰 셋팅
         fragmentAuthorReviewBottomSheetBinding.recyclerViewAuthorReview.apply {
             // 어댑터
-            adapter = RecyclerViewAdapter()
+            adapter = reviewAdapter
             // 레이아웃 매니저, 가로 방향 셋팅
             layoutManager = LinearLayoutManager(requireActivity())
             // 데코레이션
@@ -46,45 +62,7 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
         }
     }
 
-    // 작품 리사이클러 뷰 어댑터
-    inner class RecyclerViewAdapter : RecyclerView.Adapter<RecyclerViewAdapter.ViewHolder>(){
-        inner class ViewHolder(rowAuthorReviewBottomSheetBinding: RowAuthorReviewBottomSheetBinding):
-            RecyclerView.ViewHolder(rowAuthorReviewBottomSheetBinding.root){
-            val rowAuthorReviewBottomSheetBinding: RowAuthorReviewBottomSheetBinding
 
-            init {
-                this.rowAuthorReviewBottomSheetBinding = rowAuthorReviewBottomSheetBinding
-
-                this.rowAuthorReviewBottomSheetBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            val rowAuthorReviewBottomSheetBinding = RowAuthorReviewBottomSheetBinding.inflate(layoutInflater)
-            val viewHolder = ViewHolder(rowAuthorReviewBottomSheetBinding)
-            return viewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 20
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            // 닉네임
-            holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = "김토끼 $position"
-            // 댓글 내용
-            holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewText.text = "홍작가님 작품 너무 대박이에요"
-            // 삭제 버튼은 본인 댓글만 보여지게
-            if(true){
-                holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = true
-            }else{
-                holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = false
-            }
-        }
-    }
 
     // 확인 버튼
     private fun settingButtonAuthorReviewAdd(){

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorPiecesAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorPiecesAdapter.kt
@@ -1,0 +1,42 @@
+package kr.co.lion.unipiece.ui.author.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
+
+class AuthorPiecesAdapter(val piecesList: ArrayList<Int>, private val itemClickListener: (position: Int) -> Unit): RecyclerView.Adapter<AuthorPiecesViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorPiecesViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val rowAuthorPiecesBinding = RowAuthorPiecesBinding.inflate(inflater)
+        val viewHolder = AuthorPiecesViewHolder(rowAuthorPiecesBinding)
+        return viewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return piecesList.size
+    }
+
+    override fun onBindViewHolder(holder: AuthorPiecesViewHolder, position: Int) {
+        // 이미지
+        holder.rowAuthorPiecesBinding.imageViewAuthorPiece.setImageResource(piecesList[position])
+        // 작품 클릭 시 설명 화면 이동
+        holder.rowAuthorPiecesBinding.root.setOnClickListener {
+            itemClickListener(position)
+        }
+    }
+}
+
+class AuthorPiecesViewHolder(rowAuthorPiecesBinding: RowAuthorPiecesBinding):
+    RecyclerView.ViewHolder(rowAuthorPiecesBinding.root){
+    val rowAuthorPiecesBinding: RowAuthorPiecesBinding
+
+    init {
+        this.rowAuthorPiecesBinding = rowAuthorPiecesBinding
+
+        this.rowAuthorPiecesBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
@@ -1,0 +1,47 @@
+package kr.co.lion.unipiece.ui.author.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowAuthorReviewBottomSheetBinding
+
+class AuthorReviewAdapter(val reviewList: ArrayList<Any>): RecyclerView.Adapter<AuthorReviewViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorReviewViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val rowAuthorReviewBottomSheetBinding = RowAuthorReviewBottomSheetBinding.inflate(inflater)
+        val viewHolder = AuthorReviewViewHolder(rowAuthorReviewBottomSheetBinding)
+        return viewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return 20
+    }
+
+    override fun onBindViewHolder(holder: AuthorReviewViewHolder, position: Int) {
+        // 닉네임
+        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = "김토끼 $position"
+        // 댓글 내용
+        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewText.text = "홍작가님 작품 너무 대박이에요"
+        // 삭제 버튼은 본인 댓글만 보여지게
+        if(true){
+            holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = true
+        }else{
+            holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = false
+        }
+    }
+}
+
+class AuthorReviewViewHolder(rowAuthorReviewBottomSheetBinding: RowAuthorReviewBottomSheetBinding):
+    RecyclerView.ViewHolder(rowAuthorReviewBottomSheetBinding.root){
+    val rowAuthorReviewBottomSheetBinding: RowAuthorReviewBottomSheetBinding
+
+    init {
+        this.rowAuthorReviewBottomSheetBinding = rowAuthorReviewBottomSheetBinding
+
+        this.rowAuthorReviewBottomSheetBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
@@ -6,21 +6,19 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentVisitGalleryHistoryBinding
-import kr.co.lion.unipiece.databinding.RowVisitGalleryHistoryBinding
 import kr.co.lion.unipiece.ui.MainActivity
-import kr.co.lion.unipiece.util.UserInfoFragmentName
+import kr.co.lion.unipiece.ui.mypage.adapter.VisitGalleryAdapter
 import kr.co.lion.unipiece.util.VisitGalleryFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor
 
 class VisitGalleryHistoryFragment : Fragment() {
 
     lateinit var fragmentVisitGalleryHistoryBinding: FragmentVisitGalleryHistoryBinding
+    lateinit var visitAdapter: VisitGalleryAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,9 +29,14 @@ class VisitGalleryHistoryFragment : Fragment() {
 
         settingToolbar()
         settingFabApplyVisitGallery()
-        settingRecyclerView()
+
 
         return fragmentVisitGalleryHistoryBinding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        settingRecyclerView()
     }
 
     // 툴바 셋팅
@@ -83,64 +86,28 @@ class VisitGalleryHistoryFragment : Fragment() {
 
     // 리사이클러 뷰 셋팅
     private fun settingRecyclerView(){
+        // 테스트 데이터
+        val visitList = arrayListOf<Any>(
+            "test1","test2","test3","test4","test5","test6",
+            "test7","test8","test9","test10","test11","test12"
+        )
+
+        // 리사이클러뷰 어댑터
+        visitAdapter = VisitGalleryAdapter(visitList) { position ->
+            val modifyBundle = Bundle()
+            modifyBundle.putBoolean("isModify", true)
+            replaceFragment(modifyBundle)
+        }
+
+        // 리사이클러뷰 셋팅
         fragmentVisitGalleryHistoryBinding.recyclerViewVisitGalleryHistory.apply {
             // 어댑터
-            adapter = RecyclerViewAdapter()
+            adapter = visitAdapter
             // 레이아웃 매니저
             layoutManager = LinearLayoutManager(requireActivity())
             // 데코레이션
             val deco = MaterialDividerItemDecoration(requireActivity(), MaterialDividerItemDecoration.VERTICAL)
             addItemDecoration(deco)
-        }
-    }
-
-    // 리사이클러 뷰 어댑터 셋팅
-    inner class RecyclerViewAdapter : RecyclerView.Adapter<RecyclerViewAdapter.ViewHolder>(){
-        inner class ViewHolder(rowVisitGalleryHistoryBinding: RowVisitGalleryHistoryBinding):RecyclerView.ViewHolder(rowVisitGalleryHistoryBinding.root){
-            val rowVisitGalleryHistoryBinding:RowVisitGalleryHistoryBinding
-
-            init {
-                this.rowVisitGalleryHistoryBinding = rowVisitGalleryHistoryBinding
-
-                this.rowVisitGalleryHistoryBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            val rowVisitGalleryHistoryBinding = RowVisitGalleryHistoryBinding.inflate(layoutInflater)
-            val viewHolder = ViewHolder(rowVisitGalleryHistoryBinding)
-            return viewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 20
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            // 날짜
-            holder.rowVisitGalleryHistoryBinding.textViewRowVisitListDate.text="2024.04.01"
-            // 이름
-            holder.rowVisitGalleryHistoryBinding.textViewRowVisitListName.text="김길동 $position"
-            // 연락처
-            holder.rowVisitGalleryHistoryBinding.textViewRowVisitListPhoneNumber.text="010-1234-5678"
-            // 방문인원
-            holder.rowVisitGalleryHistoryBinding.textViewRowVisitListMemberCount.text="1명"
-            // 승인상태
-            holder.rowVisitGalleryHistoryBinding.textViewRowVisitListStatus.text="승인 대기중"
-            // 신청 수정 버튼 여부
-            holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.isVisible = true
-
-            // 신청 수정 버튼 클릭 이벤트
-            holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.setOnClickListener {
-                // 추후 전달할 데이터는 여기에 담기
-                val modifyBundle = Bundle()
-                modifyBundle.putBoolean("isModify", true)
-                // 회원 정보 수정 프래그먼트 교체
-                replaceFragment(modifyBundle)
-            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/VisitGalleryAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/VisitGalleryAdapter.kt
@@ -1,0 +1,57 @@
+package kr.co.lion.unipiece.ui.mypage.adapter
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowVisitGalleryHistoryBinding
+
+class VisitGalleryAdapter(val visitList: ArrayList<Any>, private val itemClickListener: (position: Int) -> Unit): RecyclerView.Adapter<VisitGalleryViewHolder>(){
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VisitGalleryViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val rowVisitGalleryHistoryBinding = RowVisitGalleryHistoryBinding.inflate(inflater, parent, false)
+        val viewHolder = VisitGalleryViewHolder(rowVisitGalleryHistoryBinding)
+        return viewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return visitList.size
+    }
+
+    override fun onBindViewHolder(holder: VisitGalleryViewHolder, position: Int) {
+        // 날짜
+        holder.rowVisitGalleryHistoryBinding.textViewRowVisitListDate.text="2024.04.01"
+        // 이름
+        holder.rowVisitGalleryHistoryBinding.textViewRowVisitListName.text="김길동 $position"
+        // 연락처
+        holder.rowVisitGalleryHistoryBinding.textViewRowVisitListPhoneNumber.text="010-1234-5678"
+        // 방문인원
+        holder.rowVisitGalleryHistoryBinding.textViewRowVisitListMemberCount.text="1명"
+        // 승인상태
+        holder.rowVisitGalleryHistoryBinding.textViewRowVisitListStatus.text="승인 대기중"
+        // 신청 수정 버튼 여부
+        holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.isVisible = true
+
+        // 신청 수정 버튼 클릭 이벤트
+        holder.rowVisitGalleryHistoryBinding.buttonRowVisitListModify.setOnClickListener {
+            // 회원 정보 수정 프래그먼트 교체
+            itemClickListener(position)
+        }
+    }
+
+}
+
+class VisitGalleryViewHolder(rowVisitGalleryHistoryBinding: RowVisitGalleryHistoryBinding):RecyclerView.ViewHolder(rowVisitGalleryHistoryBinding.root){
+    val rowVisitGalleryHistoryBinding:RowVisitGalleryHistoryBinding
+
+    init {
+        this.rowVisitGalleryHistoryBinding = rowVisitGalleryHistoryBinding
+
+        this.rowVisitGalleryHistoryBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_apply_visit_gallery.xml
+++ b/app/src/main/res/layout/fragment_apply_visit_gallery.xml
@@ -67,9 +67,9 @@
                 android:id="@+id/textViewApplyVisitGalleryMemberCount"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="32dp"
                 android:text="방문 인원"
-                android:textSize="16sp"
+                android:textSize="18sp"
                 android:textStyle="bold" />
 
             <LinearLayout
@@ -123,9 +123,9 @@
                 android:id="@+id/textViewApplyVisitGalleryDate"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="32dp"
                 android:text="방문 날짜"
-                android:textSize="16sp"
+                android:textSize="18sp"
                 android:textStyle="bold" />
 
             <LinearLayout
@@ -138,6 +138,7 @@
                     android:id="@+id/datePickerApplyVisitGallery"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
                     android:headerBackground="@color/first"
                     android:theme="@style/Theme.Material3" />
             </LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125

## 📝작업 내용

> 리사이클러뷰 어댑터 별도 파일로 분리
> 전시실 방문 신청 화면의 방문 날짜 간격 조정

### 스크린샷 (선택)

![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/d047b9dc-866e-4421-bd33-b9f81667763a)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 리사이클러뷰 어댑터 분리 이렇게 하는게 맞는건지 확인 부탁드립니다.
