### PR TITLE
[#117] feature 주문하기 뷰 추가 및 리사이클러뷰 어댑터

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/CartAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/CartAdapter.kt
@@ -1,0 +1,96 @@
+package kr.co.lion.unipiece.ui.payment.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowCartBinding
+
+class CartAdapter(private val listener: OnItemCheckStateChangeListener) : RecyclerView.Adapter<CartViewHolder>() {
+    // 장바구니 화면의 RecyclerView의 어댑터
+
+    // 항목의 선택 상태를 저장하는 리스트
+    var isCheckedList = MutableList(10) { false } // 여기서 10은 항목의 수, 초기 상태는 모두 false(선택 안됨)
+
+    // CartRecyclerViewAdapter 내부
+    fun selectAll(isChecked: Boolean) {
+        // 모든 항목의 선택 상태를 변경합니다.
+        // isSelected 파라미터 값에 따라 모든 항목을 선택하거나 선택 해제합니다.
+        isCheckedList = MutableList(itemCount) { isChecked }
+
+        // 데이터가 변경되었음을 어댑터에게 알려 UI를 갱신합니다.
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CartViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val rowCartBinding = RowCartBinding.inflate(inflater,parent,false)
+        val cartViewHolder = CartViewHolder(rowCartBinding)
+        return cartViewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return isCheckedList.size
+    }
+
+    override fun onBindViewHolder(holder: CartViewHolder, position: Int) {
+        // 체크박스 상태를 명시적으로 설정
+        // isSelectedList에서 현재 position에 해당하는 항목의 선택 상태를 가져와서
+        // 해당 항목의 체크박스 상태를 설정합니다.
+        holder.rowCartBinding.checkBoxCartRow.isChecked = isCheckedList[position]
+
+        // 체크박스 리스너 설정 전에 기존 리스너를 제거
+        // 이는 리사이클러 뷰가 뷰를 재활용할 때 발생할 수 있는 중복 클릭 이벤트를 방지하기 위함입니다.
+        holder.rowCartBinding.checkBoxCartRow.setOnCheckedChangeListener(null)
+
+        // 체크박스 클릭 리스너 설정
+        holder.rowCartBinding.checkBoxCartRow.setOnClickListener {
+            // 클릭된 항목의 현재 위치를 가져옵니다.
+            // RecyclerView에서 항목이 재활용되기 때문에 클릭 이벤트가 발생할 때
+            // 현재 항목의 정확한 위치를 얻기 위해 holder.adapterPosition을 사용합니다.
+            val currentPosition = holder.position
+
+            // 현재 항목의 선택 상태를 반전시킵니다.
+            // 현재 상태가 선택됨(true)이면 선택되지 않음(false)으로, 선택되지 않음(false)이면 선택됨(true)으로 변경합니다.
+            val isChecked = !isCheckedList[currentPosition]
+
+            // 변경된 상태를 isSelectedList에 반영합니다.
+            isCheckedList[currentPosition] = isChecked
+
+            // 해당 항목만 업데이트하여 UI를 최신 상태로 갱신합니다.
+            // 이는 성능 최적화를 위해 전체 목록을 다시 로드하는 것이 아니라 변경된 부분만 업데이트합니다.
+            notifyItemChanged(currentPosition)
+
+            // 리스너를 통해 액티비티에 체크 상태 변경을 알립니다.
+            // 모든 항목의 선택 상태를 확인한 후, 모든 항목이 선택되었다면 true, 그렇지 않다면 false를 전달합니다.
+            // 이를 통해 액티비티에서는 전체 선택 체크박스의 상태를 업데이트할 수 있습니다.
+            listener.onItemCheckStateChanged(isAllSelected())
+        }
+    }
+
+    // 모든 항목이 선택되었는지 확인하는 함수
+    fun isAllSelected(): Boolean {
+        // isSelectedList의 모든 항목이 true(선택됨)일 경우에만 true를 반환하고,
+        // 하나라도 false(선택되지 않음)가 있다면 false를 반환합니다.
+        return isCheckedList.all { it }
+    }
+}
+// 리사이클러뷰 뷰홀더
+class CartViewHolder(rowCartBinding: RowCartBinding) :
+    RecyclerView.ViewHolder(rowCartBinding.root) {
+    val rowCartBinding: RowCartBinding
+
+    init {
+        this.rowCartBinding = rowCartBinding
+
+        this.rowCartBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}
+
+interface OnItemCheckStateChangeListener {
+    fun onItemCheckStateChanged(isAllSelected: Boolean)
+}
+
+

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
@@ -4,18 +4,18 @@ import android.content.Intent
 import android.content.res.Resources
 import android.os.Bundle
 import android.util.TypedValue
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityCartBinding
-import kr.co.lion.unipiece.databinding.RowCartBinding
+import kr.co.lion.unipiece.ui.payment.adapter.CartAdapter
+import kr.co.lion.unipiece.ui.payment.adapter.OnItemCheckStateChangeListener
 import kr.co.lion.unipiece.ui.payment.order.OrderActivity
 
 class CartActivity : AppCompatActivity() {
     lateinit var activityCartBinding: ActivityCartBinding
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,7 +73,7 @@ class CartActivity : AppCompatActivity() {
                 // CartRecyclerViewAdapter의 초기화 시점에 받는 리스너
                 // 이 리스너는 항목의 체크 상태가 변경될 때 호출되어,
                 // 전체 선택 체크박스의 상태를 업데이트하는 데 사용됩니다.
-                adapter = CartRecyclerViewAdapter(object : OnItemCheckStateChangeListener {
+                adapter = CartAdapter(object : OnItemCheckStateChangeListener {
                     override fun onItemCheckStateChanged(isAllSelected: Boolean) {
                         // 모든 항목이 선택되었는지 여부에 따라 전체 선택 체크박스의 상태를 업데이트합니다.
                         checkBoxCartAll.isChecked = isAllSelected
@@ -110,100 +110,16 @@ class CartActivity : AppCompatActivity() {
                 // 어댑터를 가져와서 selectAll 함수를 호출합니다.
                 // 이때, 체크박스의 현재 상태(isChecked)를 인자로 전달합니다.
                 // 이는 모든 항목을 현재 체크박스의 상태와 동일하게 선택하거나 선택 해제하는 기능을 수행합니다.
-                val adapter = activityCartBinding.recyclerViewCartList.adapter as CartRecyclerViewAdapter
+                val adapter = activityCartBinding.recyclerViewCartList.adapter as CartAdapter
                 adapter.selectAll(isChecked)
             }
         }
     }
 
-    // 장바구니 화면의 RecyclerView의 어댑터
-    inner class CartRecyclerViewAdapter(private val listener: OnItemCheckStateChangeListener) :
-        RecyclerView.Adapter<CartRecyclerViewAdapter.CartViewHolder>() {
 
-        // 항목의 선택 상태를 저장하는 리스트
-        var isCheckedList = MutableList(10) { false } // 여기서 10은 항목의 수, 초기 상태는 모두 false(선택 안됨)
-
-        // CartRecyclerViewAdapter 내부
-        fun selectAll(isChecked: Boolean) {
-            // 모든 항목의 선택 상태를 변경합니다.
-            // isSelected 파라미터 값에 따라 모든 항목을 선택하거나 선택 해제합니다.
-            isCheckedList = MutableList(itemCount) { isChecked }
-
-            // 데이터가 변경되었음을 어댑터에게 알려 UI를 갱신합니다.
-            notifyDataSetChanged()
-        }
-
-        inner class CartViewHolder(rowCartBinding: RowCartBinding) :
-            RecyclerView.ViewHolder(rowCartBinding.root) {
-            val rowCartBinding: RowCartBinding
-
-            init {
-                this.rowCartBinding = rowCartBinding
-
-                this.rowCartBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CartViewHolder {
-            val rowCartBinding = RowCartBinding.inflate(layoutInflater)
-            val mainViewHolder = CartViewHolder(rowCartBinding)
-            return mainViewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return isCheckedList.size
-        }
-
-        override fun onBindViewHolder(holder: CartViewHolder, position: Int) {
-            // 체크박스 상태를 명시적으로 설정
-            // isSelectedList에서 현재 position에 해당하는 항목의 선택 상태를 가져와서
-            // 해당 항목의 체크박스 상태를 설정합니다.
-            holder.rowCartBinding.checkBoxCartRow.isChecked = isCheckedList[position]
-
-            // 체크박스 리스너 설정 전에 기존 리스너를 제거
-            // 이는 리사이클러 뷰가 뷰를 재활용할 때 발생할 수 있는 중복 클릭 이벤트를 방지하기 위함입니다.
-            holder.rowCartBinding.checkBoxCartRow.setOnCheckedChangeListener(null)
-
-            // 체크박스 클릭 리스너 설정
-            holder.rowCartBinding.checkBoxCartRow.setOnClickListener {
-                // 클릭된 항목의 현재 위치를 가져옵니다.
-                // RecyclerView에서 항목이 재활용되기 때문에 클릭 이벤트가 발생할 때
-                // 현재 항목의 정확한 위치를 얻기 위해 holder.adapterPosition을 사용합니다.
-                val currentPosition = holder.position
-
-                // 현재 항목의 선택 상태를 반전시킵니다.
-                // 현재 상태가 선택됨(true)이면 선택되지 않음(false)으로, 선택되지 않음(false)이면 선택됨(true)으로 변경합니다.
-                val isChecked = !isCheckedList[currentPosition]
-
-                // 변경된 상태를 isSelectedList에 반영합니다.
-                isCheckedList[currentPosition] = isChecked
-
-                // 해당 항목만 업데이트하여 UI를 최신 상태로 갱신합니다.
-                // 이는 성능 최적화를 위해 전체 목록을 다시 로드하는 것이 아니라 변경된 부분만 업데이트합니다.
-                notifyItemChanged(currentPosition)
-
-                // 리스너를 통해 액티비티에 체크 상태 변경을 알립니다.
-                // 모든 항목의 선택 상태를 확인한 후, 모든 항목이 선택되었다면 true, 그렇지 않다면 false를 전달합니다.
-                // 이를 통해 액티비티에서는 전체 선택 체크박스의 상태를 업데이트할 수 있습니다.
-                listener.onItemCheckStateChanged(isAllSelected())
-            }
-        }
-
-        // 모든 항목이 선택되었는지 확인하는 함수
-        fun isAllSelected(): Boolean {
-            // isSelectedList의 모든 항목이 true(선택됨)일 경우에만 true를 반환하고,
-            // 하나라도 false(선택되지 않음)가 있다면 false를 반환합니다.
-            return isCheckedList.all { it }
-        }
-    }
 }
 
-interface OnItemCheckStateChangeListener {
-    fun onItemCheckStateChanged(isAllSelected: Boolean)
-}
+
 
 // dp값으로 변환하는 확장함수
 inline val Int.dp: Int

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.util.TypedValue
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.marginStart
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.divider.MaterialDividerItemDecoration
@@ -28,22 +27,6 @@ class CartActivity : AppCompatActivity() {
         setRecyclerViewCart()
         clickButtonOrder()
         setCheckBoxAll()
-    }
-
-    fun setCheckBoxAll(){
-        // 전체 선택 체크박스 클릭 리스너 설정
-        activityCartBinding.checkBoxCartAll.apply {
-            setOnClickListener {
-                // 체크박스의 체크 상태를 가져옵니다.
-                val isChecked = this.isChecked
-
-                // 어댑터를 가져와서 selectAll 함수를 호출합니다.
-                // 이때, 체크박스의 현재 상태(isChecked)를 인자로 전달합니다.
-                // 이는 모든 항목을 현재 체크박스의 상태와 동일하게 선택하거나 선택 해제하는 기능을 수행합니다.
-                val adapter = activityCartBinding.recyclerViewCartList.adapter as CartRecyclerViewAdapter
-                adapter.selectAll(isChecked)
-            }
-        }
     }
 
     /////////////////////////////// 기능 구현 ///////////////////////////////////////
@@ -113,6 +96,22 @@ class CartActivity : AppCompatActivity() {
 
                 )
 
+            }
+        }
+    }
+
+    fun setCheckBoxAll(){
+        // 전체 선택 체크박스 클릭 리스너 설정
+        activityCartBinding.checkBoxCartAll.apply {
+            setOnClickListener {
+                // 체크박스의 체크 상태를 가져옵니다.
+                val isChecked = this.isChecked
+
+                // 어댑터를 가져와서 selectAll 함수를 호출합니다.
+                // 이때, 체크박스의 현재 상태(isChecked)를 인자로 전달합니다.
+                // 이는 모든 항목을 현재 체크박스의 상태와 동일하게 선택하거나 선택 해제하는 기능을 수행합니다.
+                val adapter = activityCartBinding.recyclerViewCartList.adapter as CartRecyclerViewAdapter
+                adapter.selectAll(isChecked)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
@@ -1,11 +1,15 @@
 package kr.co.lion.unipiece.ui.payment.cart
 
 import android.content.Intent
+import android.content.res.Resources
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.marginStart
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityCartBinding
 import kr.co.lion.unipiece.databinding.RowCartBinding
@@ -94,6 +98,21 @@ class CartActivity : AppCompatActivity() {
                 })
 
                 layoutManager = LinearLayoutManager(this@CartActivity)
+
+
+                // 마지막 리사이클러뷰 항목의 디바이더 삭제
+                addItemDecoration(
+                    MaterialDividerItemDecoration(this@CartActivity,
+                        (layoutManager as LinearLayoutManager).orientation
+                    ).apply {
+                        isLastItemDecorated = false
+                        setDividerColorResource(this@CartActivity,R.color.lightgray)
+                        dividerInsetEnd = 16.dp
+                        dividerInsetStart = 16.dp
+                    }
+
+                )
+
             }
         }
     }
@@ -186,3 +205,14 @@ class CartActivity : AppCompatActivity() {
 interface OnItemCheckStateChangeListener {
     fun onItemCheckStateChanged(isAllSelected: Boolean)
 }
+
+// dp값으로 변환하는 확장함수
+inline val Int.dp: Int
+    get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, this.toFloat(), Resources.getSystem().displayMetrics
+    ).toInt()
+
+inline val Float.dp: Float
+    get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, this, Resources.getSystem().displayMetrics
+    )

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -1,14 +1,17 @@
 package kr.co.lion.unipiece.ui.payment.order
 
 import android.content.Intent
+import android.content.res.Resources
 import android.os.Bundle
 import android.util.Log
+import android.util.TypedValue
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentOrderMainBinding
 import kr.co.lion.unipiece.databinding.RowCartBinding
@@ -31,7 +34,7 @@ class OrderMainFragment : Fragment() {
         fragmentOrderMainBinding = FragmentOrderMainBinding.inflate(layoutInflater)
         setToolbar()
         clickButtonDeliveryChange()
-        setRecyclerViewCart()
+        setRecyclerViewOrderMain()
 
         clickButtonPayment()
 
@@ -83,7 +86,7 @@ class OrderMainFragment : Fragment() {
 
     ///////////////////////////////// 리사이클러뷰 ///////////////////////////////////////
     // 주문하기 화면의 RecyclerView 설정
-    fun setRecyclerViewCart(){
+    fun setRecyclerViewOrderMain(){
         fragmentOrderMainBinding.apply {
             recyclerViewOrderList.apply {
                 // 어뎁터
@@ -91,6 +94,18 @@ class OrderMainFragment : Fragment() {
                 // 레이아웃 매니저
                 layoutManager = LinearLayoutManager(requireActivity())
 
+                // 마지막 리사이클러뷰 항목의 디바이더 삭제
+                addItemDecoration(
+                    MaterialDividerItemDecoration(requireActivity(),
+                        (layoutManager as LinearLayoutManager).orientation
+                    ).apply {
+                        isLastItemDecorated = false
+                        setDividerColorResource(requireActivity(),R.color.lightgray)
+                        dividerInsetEnd = 16.dp
+                        dividerInsetStart = 16.dp
+                    }
+
+                )
             }
         }
     }
@@ -126,3 +141,14 @@ class OrderMainFragment : Fragment() {
         }
     }
 }
+
+// dp값으로 변환하는 확장함수
+inline val Int.dp: Int
+    get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, this.toFloat(), Resources.getSystem().displayMetrics
+    ).toInt()
+
+inline val Float.dp: Float
+    get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, this, Resources.getSystem().displayMetrics
+    )

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentOrderMainBinding
 import kr.co.lion.unipiece.databinding.RowCartBinding
+import kr.co.lion.unipiece.databinding.RowOrderMainBinding
 import kr.co.lion.unipiece.ui.payment.cart.CartActivity
 import kr.co.lion.unipiece.ui.payment.delivery.DeliveryActivity
 
@@ -86,7 +87,7 @@ class OrderMainFragment : Fragment() {
         fragmentOrderMainBinding.apply {
             recyclerViewOrderList.apply {
                 // 어뎁터
-                adapter = OrderRecyclerViewAdapter()
+                adapter = OrderMainRecyclerViewAdapter()
                 // 레이아웃 매니저
                 layoutManager = LinearLayoutManager(requireActivity())
 
@@ -95,33 +96,33 @@ class OrderMainFragment : Fragment() {
     }
 
     // 주문하기 화면의 RecyclerView의 어뎁터
-    inner class OrderRecyclerViewAdapter :
-        RecyclerView.Adapter<OrderRecyclerViewAdapter.OrderViewHolder>() {
-        inner class OrderViewHolder(rowCartBinding: RowCartBinding) :
-            RecyclerView.ViewHolder(rowCartBinding.root) {
-            val rowCartBinding: RowCartBinding
+    inner class OrderMainRecyclerViewAdapter :
+        RecyclerView.Adapter<OrderMainRecyclerViewAdapter.OrderMainViewHolder>() {
+        inner class OrderMainViewHolder(rowOrderMainBinding: RowOrderMainBinding) :
+            RecyclerView.ViewHolder(rowOrderMainBinding.root) {
+            val rowOrderMainBinding: RowOrderMainBinding
 
             init {
-                this.rowCartBinding = rowCartBinding
-                this.rowCartBinding.root.layoutParams = ViewGroup.LayoutParams(
+                this.rowOrderMainBinding = rowOrderMainBinding
+                this.rowOrderMainBinding.root.layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.WRAP_CONTENT
                 )
             }
         }
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderViewHolder {
-            val rowCartBinding = RowCartBinding.inflate(layoutInflater)
-            val orderViewHolder = OrderViewHolder(rowCartBinding)
-            return orderViewHolder
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderMainViewHolder {
+            val rowOrderMainBinding = RowOrderMainBinding.inflate(layoutInflater)
+            val orderMainViewHolder = OrderMainViewHolder(rowOrderMainBinding)
+            return orderMainViewHolder
         }
 
         override fun getItemCount(): Int {
             return 10
         }
 
-        override fun onBindViewHolder(holder: OrderViewHolder, position: Int) {
-            holder.rowCartBinding.textViewRowCart.text = "이거슨 테스트"
+        override fun onBindViewHolder(holder: OrderMainViewHolder, position: Int) {
+            holder.rowOrderMainBinding.textViewRowOrderMain.text = "테스트라고"
         }
     }
 }

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -21,7 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="20dp">
+            android:padding="17dp">
 
             <TextView
                 android:id="@+id/textViewCartList"
@@ -36,7 +36,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:padding="3dp">
 
                 <CheckBox
                     android:id="@+id/checkBoxCartAll"
@@ -46,19 +47,26 @@
 
 
             </LinearLayout>
-
-            <androidx.cardview.widget.CardView
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:cardElevation="2dp"
-                app:cardCornerRadius="10dp">
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/recyclerViewCartList"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:clipToPadding="false"
+                android:padding="3dp">
+                <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginTop="5dp" />
-            </androidx.cardview.widget.CardView>
+                    app:cardElevation="2dp"
+                    app:cardCornerRadius="10dp">
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/recyclerViewCartList"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="5dp" />
+                </androidx.cardview.widget.CardView>
+            </LinearLayout>
+
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_order_main.xml
+++ b/app/src/main/res/layout/fragment_order_main.xml
@@ -19,7 +19,7 @@
         android:orientation="vertical"
         android:padding="20dp">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
@@ -194,7 +194,7 @@
                 </LinearLayout>
 
             </LinearLayout>
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_order_main.xml
+++ b/app/src/main/res/layout/fragment_order_main.xml
@@ -247,7 +247,7 @@
                                     android:id="@+id/textViewOrderMainBasicDeliveryPrice"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="3000원"
+                                    android:text="3,000원"
                                     android:textSize="16dp"
                                     app:layout_constraintBottom_toBottomOf="parent"
                                     app:layout_constraintEnd_toEndOf="parent"
@@ -272,7 +272,7 @@
                                     android:id="@+id/textViewOrderMainAddDeliveryPrice"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="4000원"
+                                    android:text="4,000원"
                                     android:textSize="16dp"
                                     app:layout_constraintBottom_toBottomOf="parent"
                                     app:layout_constraintEnd_toEndOf="parent"
@@ -281,9 +281,7 @@
                             <androidx.constraintlayout.widget.ConstraintLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
-                                android:clipToPadding="false"
-                                android:paddingHorizontal="3dp"
-                                android:paddingVertical="3dp">
+                                android:paddingHorizontal="10dp">
 
                                 <TextView
                                     android:id="@+id/textView6"

--- a/app/src/main/res/layout/fragment_order_main.xml
+++ b/app/src/main/res/layout/fragment_order_main.xml
@@ -17,7 +17,8 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:padding="20dp">
+        android:paddingVertical="17dp"
+        android:paddingHorizontal="17dp">
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
@@ -27,25 +28,25 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/textView1"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="10dp"
-                    android:text="배송지"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
-
-                <androidx.cardview.widget.CardView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    app:cardElevation="2dp"
-                    app:cardCornerRadius="10dp">
-
-                    <LinearLayout
+                    android:orientation="vertical"
+                    android:clipToPadding="false"
+                    android:paddingHorizontal="3dp"
+                    android:paddingVertical="3dp">
+                    <TextView
+                        android:id="@+id/textView1"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical">
+                        android:padding="10dp"
+                        android:text="배송지"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                    <androidx.cardview.widget.CardView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        app:cardElevation="2dp"
+                        app:cardCornerRadius="10dp">
 
                         <LinearLayout
                             android:layout_width="match_parent"
@@ -54,122 +55,134 @@
 
                             <LinearLayout
                                 android:layout_width="match_parent"
-                                android:layout_height="50dp"
-                                android:orientation="horizontal"
-                                android:padding="5dp">
+                                android:layout_height="wrap_content"
+                                android:orientation="vertical"
+                                android:clipToPadding="false"
+                                android:paddingHorizontal="3dp"
+                                android:paddingVertical="3dp">
 
-                                <androidx.constraintlayout.widget.ConstraintLayout
-                                    android:layout_width="match_parent"
-                                    android:layout_height="match_parent"
-                                    android:layout_weight="1">
-
-                                    <TextView
-                                        android:id="@+id/textViewOrderPersonName"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:gravity="left"
-                                        android:text="수령인"
-                                        app:layout_constraintBottom_toBottomOf="parent"
-                                        app:layout_constraintStart_toStartOf="parent"
-                                        app:layout_constraintTop_toTopOf="parent" />
-                                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                                <androidx.constraintlayout.widget.ConstraintLayout
+                                <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="50dp"
-                                    android:layout_weight="1"
+                                    android:orientation="horizontal"
                                     android:padding="5dp">
 
-                                    <Button
-                                        android:id="@+id/buttonOrderDeliveryChange"
-                                        android:layout_width="40dp"
-                                        android:layout_height="30dp"
-                                        android:background="@drawable/button_radius"
-                                        android:padding="0dp"
-                                        android:text="변경"
-                                        android:textColor="@color/white"
-                                        app:layout_constraintEnd_toEndOf="parent"
-                                        app:layout_constraintTop_toTopOf="parent" />
-                                </androidx.constraintlayout.widget.ConstraintLayout>
+                                    <androidx.constraintlayout.widget.ConstraintLayout
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent"
+                                        android:layout_weight="1">
 
-                            </LinearLayout>
+                                        <TextView
+                                            android:id="@+id/textViewOrderPersonName"
+                                            android:layout_width="wrap_content"
+                                            android:layout_height="wrap_content"
+                                            android:gravity="left"
+                                            android:text="수령인"
+                                            app:layout_constraintBottom_toBottomOf="parent"
+                                            app:layout_constraintStart_toStartOf="parent"
+                                            app:layout_constraintTop_toTopOf="parent" />
+                                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                            <TextView
-                                android:id="@+id/textViewOrderPhone"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="5dp"
-                                android:text="전화번호" />
+                                    <androidx.constraintlayout.widget.ConstraintLayout
+                                        android:layout_width="match_parent"
+                                        android:layout_height="50dp"
+                                        android:layout_weight="1"
+                                        android:padding="5dp">
 
-                            <TextView
-                                android:id="@+id/textViewOrderAddress"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="5dp"
-                                android:text="주소" />
-                            <com.google.android.material.divider.MaterialDivider
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="10dp"
-                                android:layout_marginBottom="10dp"
-                                android:layout_marginStart="10dp"
-                                android:layout_marginEnd="10dp"
-                                app:dividerColor="@color/lightgray"
-                                android:theme="@style/Theme.Material3"/>
+                                        <Button
+                                            android:id="@+id/buttonOrderDeliveryChange"
+                                            android:layout_width="40dp"
+                                            android:layout_height="30dp"
+                                            android:background="@drawable/button_radius"
+                                            android:padding="0dp"
+                                            android:text="변경"
+                                            android:textColor="@color/white"
+                                            app:layout_constraintEnd_toEndOf="parent"
+                                            app:layout_constraintTop_toTopOf="parent" />
+                                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:orientation="vertical">
+                                </LinearLayout>
 
                                 <TextView
-                                    android:id="@+id/textView2"
+                                    android:id="@+id/textViewOrderPhone"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:layout_marginLeft="5dp"
-                                    android:text="배송메모" />
+                                    android:text="전화번호" />
+
+                                <TextView
+                                    android:id="@+id/textViewOrderAddress"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="5dp"
+                                    android:text="주소" />
+                                <com.google.android.material.divider.MaterialDivider
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="10dp"
+                                    android:layout_marginBottom="10dp"
+                                    android:layout_marginStart="10dp"
+                                    android:layout_marginEnd="10dp"
+                                    app:dividerColor="@color/lightgray"
+                                    android:theme="@style/Theme.Material3"/>
 
                                 <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="match_parent"
                                     android:orientation="vertical">
 
-                                    <androidx.cardview.widget.CardView
+                                    <TextView
+                                        android:id="@+id/textView2"
                                         android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+                                        android:layout_height="wrap_content"
+                                        android:layout_marginLeft="5dp"
+                                        android:text="배송메모" />
 
-                                        <com.google.android.material.textfield.TextInputLayout
-                                            android:id="@+id/textFieldDeliveryMemoLayout"
+                                    <LinearLayout
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent"
+                                        android:orientation="vertical">
+
+                                        <androidx.cardview.widget.CardView
                                             android:layout_width="match_parent"
-                                            android:layout_height="wrap_content">
+                                            android:layout_height="match_parent">
 
-                                            <com.google.android.material.textfield.TextInputEditText
-                                                android:id="@+id/textFieldDeliveryMemoText"
+                                            <com.google.android.material.textfield.TextInputLayout
+                                                android:id="@+id/textFieldDeliveryMemoLayout"
                                                 android:layout_width="match_parent"
-                                                android:layout_height="40dp"
-                                                android:background="@color/white"
-                                                android:drawableEnd="@drawable/arrowdropdown_icon"
-                                                android:paddingLeft="15dp"
-                                                android:text="선택 안함"
-                                                android:textSize="12sp"
-                                                android:enabled="false"/>
-                                        </com.google.android.material.textfield.TextInputLayout>
-                                    </androidx.cardview.widget.CardView>
+                                                android:layout_height="wrap_content">
 
+                                                <com.google.android.material.textfield.TextInputEditText
+                                                    android:id="@+id/textFieldDeliveryMemoText"
+                                                    android:layout_width="match_parent"
+                                                    android:layout_height="40dp"
+                                                    android:background="@color/white"
+                                                    android:drawableEnd="@drawable/arrowdropdown_icon"
+                                                    android:paddingLeft="15dp"
+                                                    android:text="선택 안함"
+                                                    android:textSize="12sp"
+                                                    android:enabled="false"/>
+                                            </com.google.android.material.textfield.TextInputLayout>
+                                        </androidx.cardview.widget.CardView>
+
+
+                                    </LinearLayout>
 
                                 </LinearLayout>
 
                             </LinearLayout>
 
                         </LinearLayout>
-
-                    </LinearLayout>
-                </androidx.cardview.widget.CardView>
+                    </androidx.cardview.widget.CardView>
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:clipToPadding="false"
+                    android:paddingHorizontal="3dp"
+                    android:paddingVertical="3dp">
 
                     <TextView
                         android:id="@+id/textView3"
@@ -192,25 +205,152 @@
                     </androidx.cardview.widget.CardView>
 
                 </LinearLayout>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:clipToPadding="false"
+                    android:paddingHorizontal="3dp"
+                    android:paddingVertical="3dp">
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:padding="10dp"
+                        android:text="주문 상세"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                    <androidx.cardview.widget.CardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:cardElevation="2dp"
+                        app:cardCornerRadius="10dp">
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:orientation="vertical"
+                            android:paddingVertical="10dp">
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:paddingHorizontal="10dp">
+
+                                <TextView
+                                    android:id="@+id/textView4"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="기본배송비"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+
+                                <TextView
+                                    android:id="@+id/textViewOrderMainBasicDeliveryPrice"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="3000원"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:paddingHorizontal="10dp">
+
+                                <TextView
+                                    android:id="@+id/textView5"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="추가배송비"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+
+                                <TextView
+                                    android:id="@+id/textViewOrderMainAddDeliveryPrice"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="4000원"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:clipToPadding="false"
+                                android:paddingHorizontal="3dp"
+                                android:paddingVertical="3dp">
+
+                                <TextView
+                                    android:id="@+id/textView6"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="작품가격"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+
+                                <TextView
+                                    android:id="@+id/textViewOrderMainPiecePrice"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="15,440,979원"
+                                    android:textSize="16dp"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+                        </LinearLayout>
+                    </androidx.cardview.widget.CardView>
+                    <androidx.cardview.widget.CardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:cardElevation="2dp"
+                        app:cardCornerRadius="10dp"
+                        android:layout_marginTop="10dp"
+                        >
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:orientation="vertical"
+                            android:padding="10dp">
+
+                            <TextView
+                                android:id="@+id/textViewOrderMoney"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="주문금액"
+                                android:textSize="20dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <TextView
+                                android:id="@+id/textViewOrderMoneyMain"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="15,447,979원"
+                                android:textSize="20dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    </androidx.cardview.widget.CardView>
+                </LinearLayout>
 
             </LinearLayout>
+
         </androidx.core.widget.NestedScrollView>
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="20dp">
 
-        <TextView
-            android:id="@+id/textViewOrderMoney"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="주문금액 : "
-            android:textAlignment="textEnd" />
-    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/row_cart.xml
+++ b/app/src/main/res/layout/row_cart.xml
@@ -33,12 +33,5 @@
 
     </LinearLayout>
 
-    <com.google.android.material.divider.MaterialDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        app:dividerColor="@color/lightgray" />
-
 
 </LinearLayout>

--- a/app/src/main/res/layout/row_order_main.xml
+++ b/app/src/main/res/layout/row_order_main.xml
@@ -1,13 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/textViewOrderMain"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="TextView" />
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"
+        android:orientation="horizontal">
+        <ImageView
+            android:id="@+id/imageViewPieceRowOrderMain"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:srcCompat="@drawable/mygallery_icon" />
+        <TextView
+            android:id="@+id/textViewRowOrderMain"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:dividerColor="@color/lightgray" />
+
+
 </LinearLayout>

--- a/app/src/main/res/layout/row_order_main.xml
+++ b/app/src/main/res/layout/row_order_main.xml
@@ -24,12 +24,5 @@
 
     </LinearLayout>
 
-    <com.google.android.material.divider.MaterialDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        app:dividerColor="@color/lightgray" />
-
 
 </LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #117 

## 📝작업 내용

> 장바구니 어댑터로 분리
> 장바구니 및 주문하기 화면 수정 
> 리사이클러뷰 마지막 항목만 디바이더 삭제

![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/0a9e8c09-e926-42eb-9a98-8ecd688a8adb)

## 💬리뷰 요구사항(선택)

> 화면은 잘 뜹니다만 프래그먼트가 아니라 액티비티상에서 리사이클러뷰를 분리해서 혹시 연결과정에 불필요한게 있다면 말씀해주시면 수정하겠습니다.