### PR TITLE
[#140] 닉네임 입력 dialog 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/JoinFragment.kt
@@ -14,8 +14,6 @@ import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentJoinBinding
 import kr.co.lion.unipiece.db.remote.UserInfoDataSource
-import kr.co.lion.unipiece.model.UserInfoData
-import kr.co.lion.unipiece.repository.UserInfoRepository
 import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.LoginFragmentName
 import kr.co.lion.unipiece.util.hideSoftInput
@@ -183,6 +181,7 @@ class JoinFragment : Fragment() {
                 dialog.setButtonClickListener(object : CustomDialog.OnButtonClickListener{
                     override fun okButtonClick() {
                         requireActivity().showSoftInput(textJoinUserId)
+
 
                     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -2,6 +2,7 @@ package kr.co.lion.unipiece.ui.login
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -9,7 +10,6 @@ import android.view.ViewGroup
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentLoginBinding
 import kr.co.lion.unipiece.ui.MainActivity
-import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.LoginFragmentName
 
 
@@ -39,6 +39,21 @@ class LoginFragment : Fragment() {
                 val newIntent = Intent(requireActivity(), MainActivity::class.java)
                 startActivity(newIntent)
                 requireActivity().finish()
+            }
+            imageKaKao.setOnClickListener {
+                val dialog = NicknameDialog("닉네임 입력")
+                dialog.setNicknameButtonClickListener(object : NicknameDialog.dialogButtonClickListener{
+                    override fun nicknameOkButton() {
+                        var str = dialog.binding.nickNameDialog.text.toString()
+                        Log.d("test1234", str)
+                    }
+
+                    override fun nicknameNoButton() {
+
+                    }
+
+                })
+                dialog.show(parentFragmentManager, "CustomDialog")
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -45,7 +45,7 @@ class LoginFragment : Fragment() {
                 dialog.setNicknameButtonClickListener(object : NicknameDialog.dialogButtonClickListener{
                     override fun nicknameOkButton() {
                         var str = dialog.binding.nickNameDialog.text.toString()
-                        Log.d("test1234", str)
+
                     }
 
                     override fun nicknameNoButton() {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginViewModel.kt
@@ -1,6 +1,5 @@
 package kr.co.lion.unipiece.ui.login
 
-import android.content.pm.verify.domain.DomainVerificationUserState
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -9,7 +8,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kr.co.lion.unipiece.db.remote.UserInfoDataSource
 import kr.co.lion.unipiece.model.UserInfoData
 import kr.co.lion.unipiece.repository.UserInfoRepository
 
@@ -24,7 +22,7 @@ class LoginViewModel : ViewModel() {
 
     //회원 정보를 저장한다
     fun insertUserData(
-        userName:String, nickName:String, phoneNumber:String, userId:String, userPwd:String,
+        userName:String, nickName:String, phoneNumber: String, userId:String, userPwd:String,
         userState: Boolean, callback:(Boolean) -> Unit
     ){
         viewModelScope.launch {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/NicknameDialog.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/NicknameDialog.kt
@@ -1,0 +1,53 @@
+package kr.co.lion.unipiece.ui.login
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.textfield.TextInputEditText
+import kr.co.lion.unipiece.databinding.FragmentNicknameDialogBinding
+
+
+class NicknameDialog(val title:String) : DialogFragment() {
+
+    lateinit var binding : FragmentNicknameDialogBinding
+
+    private lateinit var buttonClickListener: dialogButtonClickListener
+
+    fun setNicknameButtonClickListener(buttonClickListener: dialogButtonClickListener){
+        this.buttonClickListener = buttonClickListener
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        binding = FragmentNicknameDialogBinding.inflate(layoutInflater)
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        binding.dialogNickname.text = title
+
+        binding.buttonNicknameOk.setOnClickListener {
+            buttonClickListener.nicknameOkButton()
+            dismiss()
+
+        }
+
+        binding.buttonNicknameNo.setOnClickListener {
+            buttonClickListener.nicknameNoButton()
+            dismiss()
+        }
+
+        return binding.root
+    }
+
+    interface dialogButtonClickListener{
+        fun nicknameOkButton()
+        fun nicknameNoButton()
+    }
+
+}

--- a/app/src/main/res/layout/fragment_nickname_dialog.xml
+++ b/app/src/main/res/layout/fragment_nickname_dialog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:background="@drawable/dialog_border"
+    android:elevation="5dp"
+    android:minWidth="300dp"
+    android:orientation="vertical"
+    android:padding="20dp"
+    tools:context=".ui.login.NicknameDialog">
+
+    <TextView
+        android:id="@+id/dialogNickname"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="TextView"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="13dp"
+        android:hint="닉네임"
+        app:boxStrokeColor="@color/second"
+        app:cursorColor="@color/second"
+        app:endIconMode="clear_text"
+        app:hintTextColor="@color/second">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/nickNameDialog"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="@drawable/textfield_radius"
+            android:paddingLeft="15dp" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="30dp"
+        android:orientation="horizontal"
+        android:paddingLeft="180dp">
+
+        <Button
+            android:id="@+id/buttonNicknameNo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="10dp"
+            android:layout_weight="1"
+            android:background="@drawable/button_radius"
+            android:text="취소"
+            android:textColor="@color/white" />
+
+        <Button
+            android:id="@+id/buttonNicknameOk"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_weight="1"
+            android:background="@drawable/button_radius"
+            android:text="확인"
+            android:textColor="@color/white" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #140 

## 📝작업 내용

> 카카오 로그인이나 네이버 로그인 시 닉네임을 입력받을 Dialog를 구현했습니

### 스크린샷 (선택)
![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/157032240/1b0e1ade-5cfa-41d9-89f8-7745d199e78a)


## 💬리뷰 요구사항(선택)

> Dialog의 버튼이름을 입력이 나을까요 아니면 지금처럼 확인이 나을까요..?
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
