### PR TITLE
[#142] 아이디 중복 검사 viewmodel 사용

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/JoinFragment.kt
@@ -226,11 +226,9 @@ class JoinFragment : Fragment() {
         fragmentJoinBinding.apply {
             buttonJoinCheckUserId.setOnClickListener {
                 viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main){
-                    val userInfoDataSource = UserInfoDataSource()
-
                     val userId = textJoinUserId.text.toString()
 
-                    checkUserId = userInfoDataSource.checkUserId(userId)
+                    checkUserId = viewModel.checkUserId(userId)
 
                     if (checkUserId == false) {
                         textJoinUserId.setText("")

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginViewModel.kt
@@ -12,9 +12,6 @@ import kr.co.lion.unipiece.model.UserInfoData
 import kr.co.lion.unipiece.repository.UserInfoRepository
 
 class LoginViewModel : ViewModel() {
-    private val _userInfo = MutableLiveData<List<UserInfoData>>()
-    val userInfo: LiveData<List<UserInfoData>> = _userInfo
-
     private val userInfoRepository = UserInfoRepository()
 
 
@@ -60,11 +57,8 @@ class LoginViewModel : ViewModel() {
 
 
     //아이디가 중복되는지 검사한다
-//    fun checkUserId(userId:String):Boolean{
-//        viewModelScope.launch{
-//            userInfoRepository.checkUserId(userId)
-//        }
-//
-//    }
+    suspend fun checkUserId(userId:String):Boolean{
+        return userInfoRepository.checkUserId(userId)
+    }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #142 

## 📝작업 내용

> 아이디 중복 검사를 ViewModel을 활용해서 구현했습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
