### PR TITLE
[#132] 작가 상세 정보 mvvm 구현 db 연동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -125,4 +125,76 @@ class AuthorInfoDataSource {
         }
         job1.join()
     }
+
+    // 작가 번호와 일치하는 팔로우 데이터를 가져와 총 개수를 반환한다.
+    suspend fun getFollowCount(authorIdx: Int): Int{
+        var count = 0
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Following")
+
+            // 컬렉션이 가지고 있는 문서들 중에 작가idx에 해당하는 데이터를 가져온다.
+            val query = collectionReference.whereEqualTo("authorIdx", authorIdx).get().await()
+
+            // 가져온 데이터의 개수를 반환한다.
+            count = query.count()
+        }
+        job1.join()
+        return count
+    }
+
+    // 해당 작가 팔로우 여부 체크
+    suspend fun checkFollow(userIdx:Int, authorIdx:Int):Boolean{
+        var check = false
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Following")
+
+            // 컬렉션이 가지고 있는 문서들 중에 회원이 해당 작가를 팔로우 한 데이터를 가져온다.
+            val query = collectionReference
+                .whereEqualTo("userIdx", userIdx)
+                .whereEqualTo("authorIdx", authorIdx)
+                .get().await()
+
+            check = query.documents.isNotEmpty()
+        }
+        job1.join()
+        return check
+    }
+
+    // 작가 팔로우 추가
+    suspend fun addAuthorFollow(userIdx:Int, authorIdx:Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Following")
+
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Any?>()
+            map["userIdx"] = userIdx
+            map["authorIdx"] = authorIdx
+
+            // 컬렉션에 문서를 추가한다.
+            collectionReference.add(map)
+        }
+        job1.join()
+    }
+
+    // 작가 팔로우 취소
+    suspend fun cancelFollowing(userIdx:Int, authorIdx:Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Following")
+
+            // 회원 번호와 작가 번호가 일치하는 문서에 접근할 수 있는 객체를 가져온다.
+            val query = collectionReference
+                .whereEqualTo("userIdx",userIdx)
+                .whereEqualTo("authorIdx",authorIdx).get().await()
+
+            // 삭제 한다.
+            query.documents[0].reference.delete()
+        }
+        job1.join()
+    }
+
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -1,0 +1,128 @@
+package kr.co.lion.unipiece.db.remote
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kr.co.lion.unipiece.model.AuthorInfoData
+
+class AuthorInfoDataSource {
+
+    private val db = Firebase.firestore
+
+    // 작가 번호 시퀀스값을 가져온다.
+    suspend fun getAuthorSequence():Int{
+
+        var authorSequence = 0
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 사용자 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("AuthorSequence")
+            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
+            val documentSnapShot = documentReference.get().await()
+
+            authorSequence = documentSnapShot.getLong("value")?.toInt()!!
+        }
+        job1.join()
+
+        return authorSequence
+    }
+
+    // 작가 시퀀스 값을 업데이트 한다.
+    suspend fun updateAuthorSequence(authorSequence: Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("AuthorSequence")
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Long>()
+            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
+            map["value"] = authorSequence.toLong()
+            // 저장한다.
+            documentReference.set(map)
+        }
+        job1.join()
+    }
+
+    // 작가 정보를 저장한다.
+    suspend fun insertAuthorInfoData(authorInfoData: AuthorInfoData){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("AuthorInfo")
+            // 컬렉션에 문서를 추가한다.
+            // 문서를 추가할 때 객체나 맵을 지정한다.
+            // 추가된 문서 내부의 필드는 객체가 가진 프로퍼티의 이름이나 맵에 있는 데이터의 이름으로 동일하게 결정된다.
+            collectionReference.add(authorInfoData)
+        }
+        job1.join()
+    }
+
+    // 작가 번호를 통해 작가 정보를 가져와 반환한다
+    suspend fun getAuthorInfoDataByIdx(authorIdx:Int) : AuthorInfoData? {
+
+        var authorInfoData:AuthorInfoData? = null
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // AuthorInfo 컬렉션 접근 객체를 가져온다.
+            val collectionReference = db.collection("AuthorInfo")
+            // authorIdx 필드가 매개변수로 들어오는 authorIdx와 같은 문서들을 가져온다.
+            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).get().await()
+            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
+            // 회원 번호가 동일한 사용는 없기 때문에 무조건 하나만 나오기 때문이다
+            authorInfoData = querySnapshot.documents[0].toObject(AuthorInfoData::class.java)
+        }
+        job1.join()
+
+        return authorInfoData
+    }
+
+    // 모든 작가의 정보를 가져온다.
+    suspend fun getAuthorInfoAll():MutableList<AuthorInfoData>{
+        // 사용자 정보를 담을 리스트
+        val authorList = mutableListOf<AuthorInfoData>()
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 모든 사용자 정보를 가져온다.
+            val querySnapshot = db.collection("AuthorInfo").get().await()
+            // 가져온 문서의 수 만큼 반복한다.
+            querySnapshot.forEach {
+                // UserModel 객체에 담는다.
+                val authorInfoData = it.toObject(AuthorInfoData::class.java)
+                // 리스트에 담는다.
+                authorList.add(authorInfoData)
+            }
+        }
+        job1.join()
+
+        return authorList
+    }
+
+
+    // 작가 정보를 수정하는 메서드
+    suspend fun updateAuthorInfoData(authorInfoData: AuthorInfoData){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("AuthorInfo")
+
+            // 컬렉션이 가지고 있는 문서들 중에 수정할 작가 정보를 가져온다.
+            val query = collectionReference.whereEqualTo("authorIdx", authorInfoData.authorIdx).get().await()
+
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Any?>()
+            map["authorImg"] = authorInfoData.authorImg
+            map["authorName"] = authorInfoData.authorName
+            map["authorBasic"] = authorInfoData.authorBasic
+            map["authorInfo"] = authorInfoData.authorInfo
+
+            // 저장한다.
+            // 가져온 문서 중 첫 번째 문서에 접근하여 데이터를 수정한다.
+            query.documents[0].reference.update(map)
+        }
+        job1.join()
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
@@ -1,6 +1,6 @@
 package kr.co.lion.unipiece.model
 
-import java.util.Date
+import com.google.firebase.Timestamp
 
 data class AuthorInfoData(
     var userIdx: Int,
@@ -10,8 +10,7 @@ data class AuthorInfoData(
     var authorBasic: String,
     var authorInfo: String,
     var authorSale: String,
-    var authorFollower: String,
-    var authorDate: Date,
+    var authorDate: Timestamp,
 ){
-    constructor() : this(0, 0, "", "무명", "OO대학 OO학과", "작가 소개하는 내용", "", "128", Date())
+    constructor() : this(0, 0, "", "무명", "OO대학 OO학과", "작가 소개하는 내용", "", Timestamp.now())
 }

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
@@ -1,0 +1,15 @@
+package kr.co.lion.unipiece.model
+
+data class AuthorInfoData(
+    var userIdx: Int,
+    var authorIdx: Int,
+    var authorImg: String,
+    var authorName: String,
+    var authorBasic: String,
+    var authorInfo: String,
+    var authorSale: String,
+    var authorFollower: String,
+    var authorDate: String,
+){
+    constructor() : this(0, 0, "", "", "", "", "", "", "")
+}

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
@@ -11,5 +11,5 @@ data class AuthorInfoData(
     var authorFollower: String,
     var authorDate: String,
 ){
-    constructor() : this(0, 0, "", "", "", "", "", "", "")
+    constructor() : this(0, 0, "", "무명작가", "OO대학 OO학과", "작가 소개하는 내용", "", "128", "")
 }

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
@@ -1,5 +1,7 @@
 package kr.co.lion.unipiece.model
 
+import java.util.Date
+
 data class AuthorInfoData(
     var userIdx: Int,
     var authorIdx: Int,
@@ -9,7 +11,7 @@ data class AuthorInfoData(
     var authorInfo: String,
     var authorSale: String,
     var authorFollower: String,
-    var authorDate: String,
+    var authorDate: Date,
 ){
-    constructor() : this(0, 0, "", "무명작가", "OO대학 OO학과", "작가 소개하는 내용", "", "128", "")
+    constructor() : this(0, 0, "", "무명", "OO대학 OO학과", "작가 소개하는 내용", "", "128", Date())
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -23,4 +23,16 @@ class AuthorInfoRepository {
 
     // 작가 정보를 수정하는 메서드
     suspend fun updateAuthorInfoData(authorInfoData: AuthorInfoData) = authorInfoDataSource.updateAuthorInfoData(authorInfoData)
+
+    // 작가 팔로우 수를 가져오는 메서드
+    suspend fun getAuthorFollow(authorIdx: Int) = authorInfoDataSource.getFollowCount(authorIdx)
+
+    // 해당 작가 팔로우 여부 체크
+    suspend fun checkFollow(userIdx:Int, authorIdx:Int) = authorInfoDataSource.checkFollow(userIdx, authorIdx)
+
+    // 작가 팔로우 추가
+    suspend fun addAuthorFollow(userIdx:Int, authorIdx:Int) = authorInfoDataSource.addAuthorFollow(userIdx, authorIdx)
+
+    // 작가 팔로우 취소
+    suspend fun cancelFollowing(userIdx:Int, authorIdx:Int) = authorInfoDataSource.cancelFollowing(userIdx, authorIdx)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -1,0 +1,26 @@
+package kr.co.lion.unipiece.repository
+
+import kr.co.lion.unipiece.db.remote.AuthorInfoDataSource
+import kr.co.lion.unipiece.model.AuthorInfoData
+
+class AuthorInfoRepository {
+    private val authorInfoDataSource = AuthorInfoDataSource()
+
+    // 작가 번호 시퀀스값을 가져온다.
+    suspend fun getAuthorSequence() = authorInfoDataSource.getAuthorSequence()
+
+    // 작가 시퀀스 값을 업데이트 한다.
+    suspend fun updateAuthorSequence(authorSequence: Int) = authorInfoDataSource.updateAuthorSequence(authorSequence)
+
+    // 작가 정보를 저장한다.
+    suspend fun insertAuthorInfoData(authorInfoData: AuthorInfoData) = authorInfoDataSource.insertAuthorInfoData(authorInfoData)
+
+    // 작가 번호를 통해 작가 정보를 가져와 반환한다
+    suspend fun getAuthorInfoDataByIdx(authorIdx:Int) = authorInfoDataSource.getAuthorInfoDataByIdx(authorIdx)
+
+    // 모든 작가의 정보를 가져온다.
+    suspend fun getAuthorInfoAll():MutableList<AuthorInfoData> = authorInfoDataSource.getAuthorInfoAll()
+
+    // 작가 정보를 수정하는 메서드
+    suspend fun updateAuthorInfoData(authorInfoData: AuthorInfoData) = authorInfoDataSource.updateAuthorInfoData(authorInfoData)
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
@@ -24,6 +24,10 @@ class AuthorInfoActivity : AppCompatActivity() {
 
         // 추후 전달할 데이터는 여기에 담기
         val authorInfoBundle = Bundle()
+        // 이전 액티비티에서 authorIdx와 userIdx를 받아온다.
+        // 수정 필요
+        authorInfoBundle.putInt("authorIdx",1)
+        authorInfoBundle.putInt("userIdx",2)
 
         replaceFragment(AuthorInfoFragmentName.AUTHOR_INFO_FRAGMENT, false, authorInfoBundle)
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -2,7 +2,6 @@ package kr.co.lion.unipiece.ui.author
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -15,7 +14,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.google.firebase.Timestamp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
@@ -32,10 +30,12 @@ class AuthorInfoFragment : Fragment() {
     lateinit var authorPiecesAdapter: AuthorPiecesAdapter
     val authorInfoViewModel: AuthorInfoViewModel by viewModels()
 
-    // 이전 액티비티에서 작가Idx, 회원Idx 받아오기 추후 수정 필요
-    // val authorIdx = requireArguments().getInt("authorIdx",1)
-    val authorIdx = 1
-    val userIdx = 2
+    val authorIdx by lazy {
+        requireArguments().getInt("authorIdx")
+    }
+    val userIdx by lazy {
+        requireArguments().getInt("userIdx")
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -75,7 +75,7 @@ class AuthorInfoFragment : Fragment() {
                 lifecycleScope.launch {
                     // 추후 수정 필요
                     val authorCheck = authorInfoViewModel!!.checkAuthor()
-                    if(authorCheck){
+                    if(!authorCheck){ // 나중에 ! 제거
                         // 작가 본인인 경우 작가 정보 수정 아이콘 표시
                         menu.findItem(R.id.menu_edit).isVisible = true
                     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -29,7 +30,7 @@ class AuthorInfoFragment : Fragment() {
 
     lateinit var fragmentAuthorInfoBinding: FragmentAuthorInfoBinding
     lateinit var authorPiecesAdapter: AuthorPiecesAdapter
-    lateinit var authorInfoViewModel: AuthorInfoViewModel
+    val authorInfoViewModel: AuthorInfoViewModel by viewModels()
 
     // 이전 액티비티에서 작가Idx, 회원Idx 받아오기 추후 수정 필요
     // val authorIdx = requireArguments().getInt("authorIdx",1)
@@ -42,7 +43,6 @@ class AuthorInfoFragment : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
         fragmentAuthorInfoBinding = FragmentAuthorInfoBinding.inflate(inflater)
-        authorInfoViewModel = AuthorInfoViewModel()
         fragmentAuthorInfoBinding.authorInfoViewModel = authorInfoViewModel
         fragmentAuthorInfoBinding.lifecycleOwner = this
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -1,7 +1,6 @@
 package kr.co.lion.unipiece.ui.author
 
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -14,8 +13,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
@@ -180,6 +177,10 @@ class AuthorInfoFragment : Fragment() {
         // 리뷰 버튼 클릭 시 리뷰 프래그먼트 보이기
         fragmentAuthorInfoBinding.buttonAuthorReview.setOnClickListener {
             val authorReviewBottomSheetFragment = AuthorReviewBottomSheetFragment()
+            authorReviewBottomSheetFragment.arguments = Bundle().apply {
+                putInt("userIdx", userIdx)
+                putInt("authorIdx", authorIdx)
+            }
             authorReviewBottomSheetFragment.show(parentFragmentManager, "BottomSheet")
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -10,9 +10,11 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
 import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
+import kr.co.lion.unipiece.model.AuthorInfoData
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
@@ -26,6 +28,7 @@ class AuthorInfoFragment : Fragment() {
 
     lateinit var fragmentAuthorInfoBinding: FragmentAuthorInfoBinding
     lateinit var authorPiecesAdapter: AuthorPiecesAdapter
+    lateinit var authorInfoViewModel: AuthorInfoViewModel
 
     // 작가 팔로우 여부
     var authorFollow = false
@@ -36,6 +39,9 @@ class AuthorInfoFragment : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
         fragmentAuthorInfoBinding = FragmentAuthorInfoBinding.inflate(inflater)
+        authorInfoViewModel = AuthorInfoViewModel()
+        fragmentAuthorInfoBinding.authorInfoViewModel = authorInfoViewModel
+        fragmentAuthorInfoBinding.lifecycleOwner = this
 
         settingToolbar()
         initView()
@@ -102,17 +108,37 @@ class AuthorInfoFragment : Fragment() {
     }
 
     private fun initView(){
+        // 작가 데이터 받아오기
+        val authorInfoData = AuthorInfoData()
+        // 받아온 데이터로 작가 객체 초기화
+        
+        // 뷰모델과 연결
+        authorInfoViewModel.authorName.value = authorInfoData.authorName
+        authorInfoViewModel.authorFollower.value = authorInfoData.authorFollower + " 명 팔로우"
+        authorInfoViewModel.authorBasic.value = authorInfoData.authorBasic
+        authorInfoViewModel.authorInfo.value = authorInfoData.authorInfo
+
+        // 회원 정보 데이터 받아오기
+
+        // 받아온 데이터로 회원 정보 객체 초기화
+
         // 회원 유형에 따라 팔로우, 리뷰 버튼 표시
         fragmentAuthorInfoBinding.apply {
-            // 작가가 아니면
+            
             // 추후 수정
-            if(true){
+            if(1==authorInfoData.userIdx){
                 buttonAuthorFollow.isVisible = true
                 buttonAuthorReview.isVisible = true
             }else{
+                // 사용자가 해당 작가인 경우
                 buttonAuthorFollow.isVisible = false
                 buttonAuthorReview.isVisible = false
             }
+            
+            // 작가 이미지 넣기
+            Glide.with(requireActivity())
+                .load(authorInfoData.authorImg)
+                .into(imageViewAuthor)
         }
     }
 
@@ -128,19 +154,10 @@ class AuthorInfoFragment : Fragment() {
 
     // 팔로우 버튼 변경
     private fun changeFollowButton(){
-        val followButton = fragmentAuthorInfoBinding.buttonAuthorFollow
-        if(authorFollow){
-            followButton.apply {
-                setBackgroundResource(R.drawable.button_radius)
-                setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
-                text = "팔로잉"
-            }
-        }else{
-            followButton.apply {
-                setBackgroundResource(R.drawable.button_radius2)
-                setTextColor(ContextCompat.getColor(requireActivity(), R.color.first))
-                text = "팔로우"
-            }
+        with(fragmentAuthorInfoBinding.buttonAuthorFollow){
+            authorInfoViewModel.changeFollowState(authorFollow)
+            setTextColor(authorInfoViewModel.buttonAuthorFollowTextColor.value!!)
+            setBackgroundResource(authorInfoViewModel.buttonAuthorFollowBackground.value!!)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -71,12 +71,14 @@ class AuthorInfoFragment : Fragment() {
                 }
 
                 // 회원 유형에 따라 메뉴 아이콘 다르게 표시
-                // 추후 수정 필요
-                if(true){
-                    // 작가 본인인 경우 작가 정보 수정 아이콘 표시
-                    menu.findItem(R.id.menu_edit).isVisible = true
-                }else{
-                    menu.findItem(R.id.menu_edit).isVisible = false
+                menu.findItem(R.id.menu_edit).isVisible = false
+                lifecycleScope.launch {
+                    // 추후 수정 필요
+                    val authorCheck = authorInfoViewModel!!.checkAuthor()
+                    if(authorCheck){
+                        // 작가 본인인 경우 작가 정보 수정 아이콘 표시
+                        menu.findItem(R.id.menu_edit).isVisible = true
+                    }
                 }
 
                 // 툴바 메뉴 클릭 이벤트
@@ -114,6 +116,16 @@ class AuthorInfoFragment : Fragment() {
                 // 작가 정보 불러오기
                 authorInfoViewModel!!.getAuthorInfoData(authorIdx)
 
+                // 추후 수정 필요
+                val authorCheck = authorInfoViewModel!!.checkAuthor()
+                // 회원 유형에 따라 팔로우, 리뷰 버튼 표시
+                // 추후 수정
+                if(authorCheck){
+                    // 사용자가 해당 작가인 경우
+                    buttonAuthorFollow.isVisible = false
+                    buttonAuthorReview.isVisible = false
+                }
+
                 // 팔로워 수 불러오기
                 authorInfoViewModel!!.getFollowCount(authorIdx)
 
@@ -121,17 +133,6 @@ class AuthorInfoFragment : Fragment() {
                 Glide.with(requireActivity())
                     .load(authorInfoViewModel!!.authorInfoData.value?.authorImg)
                     .into(imageViewAuthor)
-            }
-
-            // 회원 유형에 따라 팔로우, 리뷰 버튼 표시
-            // 추후 수정
-            if(true){
-                buttonAuthorFollow.isVisible = true
-                buttonAuthorReview.isVisible = true
-            }else{
-                // 사용자가 해당 작가인 경우
-                buttonAuthorFollow.isVisible = false
-                buttonAuthorReview.isVisible = false
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
@@ -34,8 +34,8 @@ class AuthorInfoViewModel: ViewModel() {
 
     // 본인이 해당 작가인지 여부 확인
     // 추후 수정
-    suspend fun checkAuthor(): Boolean{
-        return false
+    fun checkAuthor(userIdx: Int): Boolean{
+        return authorInfoData.value?.userIdx == userIdx
     }
 
     // 팔로우 수 불러오기

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
@@ -35,7 +35,7 @@ class AuthorInfoViewModel: ViewModel() {
     // 본인이 해당 작가인지 여부 확인
     // 추후 수정
     suspend fun checkAuthor(): Boolean{
-        return true
+        return false
     }
 
     // 팔로우 수 불러오기

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
@@ -1,0 +1,40 @@
+package kr.co.lion.unipiece.ui.author
+
+import android.graphics.Color
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import kr.co.lion.unipiece.R
+
+class AuthorInfoViewModel: ViewModel() {
+    // 작가 이름
+    val authorName = MutableLiveData<String>()
+    // 팔로워 수
+    val authorFollower = MutableLiveData<String>()
+    // 작가 기본 정보
+    val authorBasic = MutableLiveData<String>()
+    // 작가 소개
+    val authorInfo = MutableLiveData<String>()
+    // 작가 이미지
+    val authorImage = MutableLiveData<String>()
+
+    // 팔로우 버튼 배경이미지
+    val buttonAuthorFollowBackground = MutableLiveData<Int>()
+    // 팔로우 버튼 텍스트 색
+    val buttonAuthorFollowTextColor = MutableLiveData<Int>()
+    // 팔로우 버튼 텍스트
+    val buttonAuthorFollowText = MutableLiveData<String>()
+
+    // 팔로우 버튼 상태 변경
+    fun changeFollowState(state:Boolean){
+        if(state){
+            buttonAuthorFollowBackground.value = R.drawable.button_radius
+            buttonAuthorFollowTextColor.value = Color.WHITE
+            buttonAuthorFollowText.value = "팔로잉"
+        }else{
+            buttonAuthorFollowBackground.value = R.drawable.button_radius2
+            buttonAuthorFollowTextColor.value = R.color.first
+            buttonAuthorFollowText.value = "팔로우"
+        }
+
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
@@ -32,6 +32,12 @@ class AuthorInfoViewModel: ViewModel() {
         job1.join()
     }
 
+    // 본인이 해당 작가인지 여부 확인
+    // 추후 수정
+    suspend fun checkAuthor(): Boolean{
+        return true
+    }
+
     // 팔로우 수 불러오기
     fun getFollowCount(authorIdx: Int){
         viewModelScope.launch {
@@ -63,6 +69,7 @@ class AuthorInfoViewModel: ViewModel() {
     }
 
     // 작가의 작품 리스트 불러오기
+    // 추후 수정
     fun getPiecesList(authorIdx:Int){
 
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoViewModel.kt
@@ -1,40 +1,69 @@
 package kr.co.lion.unipiece.ui.author
 
-import android.graphics.Color
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kr.co.lion.unipiece.R
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.model.AuthorInfoData
+import kr.co.lion.unipiece.repository.AuthorInfoRepository
 
 class AuthorInfoViewModel: ViewModel() {
-    // 작가 이름
-    val authorName = MutableLiveData<String>()
-    // 팔로워 수
-    val authorFollower = MutableLiveData<String>()
-    // 작가 기본 정보
-    val authorBasic = MutableLiveData<String>()
-    // 작가 소개
-    val authorInfo = MutableLiveData<String>()
-    // 작가 이미지
-    val authorImage = MutableLiveData<String>()
+    // 작가 정보
+    private val _authorInfoData = MutableLiveData<AuthorInfoData>()
+    val authorInfoData:LiveData<AuthorInfoData> = _authorInfoData
 
-    // 팔로우 버튼 배경이미지
-    val buttonAuthorFollowBackground = MutableLiveData<Int>()
-    // 팔로우 버튼 텍스트 색
-    val buttonAuthorFollowTextColor = MutableLiveData<Int>()
-    // 팔로우 버튼 텍스트
-    val buttonAuthorFollowText = MutableLiveData<String>()
+    // 작가 팔로우 수
+    private val _authorFollow = MutableLiveData<String>()
+    val authorFollow:LiveData<String> = _authorFollow
 
-    // 팔로우 버튼 상태 변경
-    fun changeFollowState(state:Boolean){
-        if(state){
-            buttonAuthorFollowBackground.value = R.drawable.button_radius
-            buttonAuthorFollowTextColor.value = Color.WHITE
-            buttonAuthorFollowText.value = "팔로잉"
-        }else{
-            buttonAuthorFollowBackground.value = R.drawable.button_radius2
-            buttonAuthorFollowTextColor.value = R.color.first
-            buttonAuthorFollowText.value = "팔로우"
+    // 팔로우 여부
+    private val _checkFollow = MutableLiveData<Boolean>()
+    val checkFollow:LiveData<Boolean> = _checkFollow
+
+    private val authorInfoRepository = AuthorInfoRepository()
+
+    // 작가 정보를 불러오기
+    suspend fun getAuthorInfoData(authorIdx: Int) {
+        val job1 = viewModelScope.launch {
+            // 작가 정보 객체 셋팅
+            _authorInfoData.value = authorInfoRepository.getAuthorInfoDataByIdx(authorIdx)
         }
+        job1.join()
+    }
+
+    // 팔로우 수 불러오기
+    fun getFollowCount(authorIdx: Int){
+        viewModelScope.launch {
+            val followCount = authorInfoRepository.getAuthorFollow(authorIdx)
+            _authorFollow.value = "${followCount} 팔로워"
+        }
+    }
+
+    // 팔로우 여부 확인
+    fun checkFollow(userIdx:Int, authorIdx:Int){
+        viewModelScope.launch {
+            _checkFollow.value = authorInfoRepository.checkFollow(userIdx, authorIdx)
+        }
+    }
+
+    // 팔로우 하기
+    suspend fun followAuthor(userIdx:Int, authorIdx:Int){
+        val job1 = viewModelScope.launch {
+            authorInfoRepository.addAuthorFollow(userIdx, authorIdx)
+        }
+        job1.join()
+    }
+    // 팔로우 취소
+    suspend fun cancelFollowing(userIdx:Int, authorIdx:Int){
+        val job1 = viewModelScope.launch {
+            authorInfoRepository.cancelFollowing(userIdx, authorIdx)
+        }
+        job1.join()
+    }
+
+    // 작가의 작품 리스트 불러오기
+    fun getPiecesList(authorIdx:Int){
 
     }
 }

--- a/app/src/main/res/layout/fragment_author_info.xml
+++ b/app/src/main/res/layout/fragment_author_info.xml
@@ -76,7 +76,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_weight="1"
-                                android:text="@{authorInfoViewModel.authorName}"
+                                android:text="@{authorInfoViewModel.authorInfoData.authorName+` 작가`}"
                                 android:textAlignment="center"
                                 android:textColor="@color/black"
                                 android:textSize="20sp"
@@ -87,7 +87,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_weight="1"
-                                android:text="@{authorInfoViewModel.authorFollower}"
+                                android:text="@{authorInfoViewModel.authorFollow}"
                                 android:textColor="@color/black"
                                 android:textSize="16sp"
                                 android:textStyle="bold" />
@@ -108,7 +108,7 @@
                                 android:background="@drawable/button_radius2"
                                 android:paddingTop="0dp"
                                 android:paddingBottom="0dp"
-                                android:text="@{authorInfoViewModel.buttonAuthorFollowText}"
+                                android:text="팔로우"
                                 android:textColor="@color/first"
                                 android:textSize="14sp"
                                 android:textStyle="bold" />
@@ -140,7 +140,7 @@
                     android:paddingTop="5dp"
                     android:paddingRight="16dp"
                     android:paddingBottom="5dp"
-                    android:text="@{authorInfoViewModel.authorBasic}"
+                    android:text="@{authorInfoViewModel.authorInfoData.authorBasic}"
                     android:textColor="@color/black" />
 
                 <TextView
@@ -159,7 +159,7 @@
                     android:layout_marginTop="5dp"
                     android:background="@drawable/textfield_radius"
                     android:padding="16dp"
-                    android:text="@{authorInfoViewModel.authorInfo}"
+                    android:text="@{authorInfoViewModel.authorInfoData.authorInfo}"
                     android:textColor="@color/black" />
 
                 <TextView

--- a/app/src/main/res/layout/fragment_author_info.xml
+++ b/app/src/main/res/layout/fragment_author_info.xml
@@ -1,175 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.author.AuthorInfoFragment">
+    xmlns:tools="http://schemas.android.com/tools">
+    
+    <data>
+        <variable
+            name="authorInfoViewModel"
+            type="kr.co.lion.unipiece.ui.author.AuthorInfoViewModel" />
+    </data>
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbarAuthorInfo"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="64dp"
-        android:background="@color/white"
-        android:minHeight="?attr/actionBarSize"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:theme="?attr/actionBarTheme"
-        app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".ui.author.AuthorInfoFragment">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <LinearLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarAuthorInfo"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="20dp">
+            android:layout_height="64dp"
+            android:background="@color/white"
+            android:minHeight="?attr/actionBarSize"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:theme="?attr/actionBarTheme"
+            app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
-
-                <androidx.cardview.widget.CardView
-                    android:id="@+id/cardViewImageAuthor"
-                    android:layout_width="100dp"
-                    android:layout_height="100dp"
-                    android:layout_gravity="center"
-                    app:cardCornerRadius="50dp">
-
-                    <ImageView
-                        android:id="@+id/imageViewAuthor"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:src="@drawable/ic_launcher_background" />
-                </androidx.cardview.widget.CardView>
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginLeft="16dp"
-                    android:layout_weight="4"
-                    android:gravity="center"
-                    android:orientation="vertical">
+                    android:orientation="horizontal">
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/cardViewImageAuthor"
+                        android:layout_width="100dp"
+                        android:layout_height="100dp"
+                        android:layout_gravity="center"
+                        app:cardCornerRadius="50dp">
+
+                        <ImageView
+                            android:id="@+id/imageViewAuthor"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:src="@drawable/ic_launcher_background" />
+                    </androidx.cardview.widget.CardView>
 
                     <LinearLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal">
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginLeft="16dp"
+                        android:layout_weight="4"
+                        android:gravity="center"
+                        android:orientation="vertical">
 
-                        <TextView
-                            android:id="@+id/textViewAuthorName"
-                            android:layout_width="wrap_content"
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:text="홍길동"
-                            android:textAlignment="center"
-                            android:textColor="@color/black"
-                            android:textSize="20sp"
-                            android:textStyle="bold" />
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal">
 
-                        <TextView
-                            android:id="@+id/textViewAuthorFollower"
-                            android:layout_width="wrap_content"
+                            <TextView
+                                android:id="@+id/textViewAuthorName"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@{authorInfoViewModel.authorName}"
+                                android:textAlignment="center"
+                                android:textColor="@color/black"
+                                android:textSize="20sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:id="@+id/textViewAuthorFollower"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@{authorInfoViewModel.authorFollower}"
+                                android:textColor="@color/black"
+                                android:textSize="16sp"
+                                android:textStyle="bold" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:text="125 팔로워"
-                            android:textColor="@color/black"
-                            android:textSize="16sp"
-                            android:textStyle="bold" />
-                    </LinearLayout>
+                            android:layout_marginTop="5dp"
+                            android:orientation="horizontal">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="5dp"
-                        android:orientation="horizontal">
+                            <Button
+                                android:id="@+id/buttonAuthorFollow"
+                                android:layout_width="wrap_content"
+                                android:layout_height="30dp"
+                                android:layout_marginRight="5dp"
+                                android:layout_weight="1"
+                                android:background="@drawable/button_radius2"
+                                android:paddingTop="0dp"
+                                android:paddingBottom="0dp"
+                                android:text="@{authorInfoViewModel.buttonAuthorFollowText}"
+                                android:textColor="@color/first"
+                                android:textSize="14sp"
+                                android:textStyle="bold" />
 
-                        <Button
-                            android:id="@+id/buttonAuthorFollow"
-                            android:layout_width="wrap_content"
-                            android:layout_height="30dp"
-                            android:layout_marginRight="5dp"
-                            android:layout_weight="1"
-                            android:background="@drawable/button_radius2"
-                            android:paddingTop="0dp"
-                            android:paddingBottom="0dp"
-                            android:text="팔로우"
-                            android:textColor="@color/first"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
-
-                        <Button
-                            android:id="@+id/buttonAuthorReview"
-                            android:layout_width="wrap_content"
-                            android:layout_height="30dp"
-                            android:layout_marginLeft="5dp"
-                            android:layout_weight="1"
-                            android:background="@drawable/button_radius"
-                            android:paddingTop="0dp"
-                            android:paddingBottom="0dp"
-                            android:text="리뷰"
-                            android:textColor="@color/white"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
+                            <Button
+                                android:id="@+id/buttonAuthorReview"
+                                android:layout_width="wrap_content"
+                                android:layout_height="30dp"
+                                android:layout_marginLeft="5dp"
+                                android:layout_weight="1"
+                                android:background="@drawable/button_radius"
+                                android:paddingTop="0dp"
+                                android:paddingBottom="0dp"
+                                android:text="리뷰"
+                                android:textColor="@color/white"
+                                android:textSize="14sp"
+                                android:textStyle="bold" />
+                        </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>
+
+                <TextView
+                    android:id="@+id/textViewAuthorBasicInfo"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/textfield_radius"
+                    android:paddingLeft="16dp"
+                    android:paddingTop="5dp"
+                    android:paddingRight="16dp"
+                    android:paddingBottom="5dp"
+                    android:text="@{authorInfoViewModel.authorBasic}"
+                    android:textColor="@color/black" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:text="작가 소개"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/textViewAuthorDetailInfo"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:layout_marginTop="5dp"
+                    android:background="@drawable/textfield_radius"
+                    android:padding="16dp"
+                    android:text="@{authorInfoViewModel.authorInfo}"
+                    android:textColor="@color/black" />
+
+                <TextView
+                    android:id="@+id/textView6"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:text="작품"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerViewAuthorPieces"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="5dp" />
+
             </LinearLayout>
+        </ScrollView>
 
-            <TextView
-                android:id="@+id/textViewAuthorBasicInfo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/textfield_radius"
-                android:paddingLeft="16dp"
-                android:paddingTop="5dp"
-                android:paddingRight="16dp"
-                android:paddingBottom="5dp"
-                android:text="00대학 00학과"
-                android:textColor="@color/black" />
+    </LinearLayout>
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="32dp"
-                android:text="작가 소개"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/textViewAuthorDetailInfo"
-                android:layout_width="match_parent"
-                android:layout_height="150dp"
-                android:layout_marginTop="5dp"
-                android:background="@drawable/textfield_radius"
-                android:padding="16dp"
-                android:text="홍익대학교 미술대학 조소과 졸업 예정  멋진사람들예술공모전 금상 수상 사자예술공모전 은상 수상"
-                android:textColor="@color/black" />
-
-            <TextView
-                android:id="@+id/textView6"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="32dp"
-                android:text="작품"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerViewAuthorPieces"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="5dp" />
-
-        </LinearLayout>
-    </ScrollView>
-
-</LinearLayout>
+</layout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #132 

## 📝작업 내용

> 작가 상세 정보만 작업
> 이전 액티비티에서 회원idx, 작가idx 전달받아야 함
> 팔로우 버튼 클릭 시 팔로우 수 증가, 팔로잉 버튼 클릭 시 팔로우 취소
> 작가 리뷰 및 작품 리사이클러뷰는 작업 예정
> 유저 본인이 해당 작가인 경우를 체크해서 수정, 팔로우,리뷰 버튼 표시하는 부분도 작업 예정

### 스크린샷 (선택)
[authorinfo.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/c1ad3cc8-419b-4c37-b708-3871864c6125)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 유저 본인이 해당 작가인지 여부를 확인해야 수정, 팔로우, 리뷰 버튼 표시 여부를 결정할 수 있어서,
> 유저 정보 컬렉션에 작가인 경우에만 작가idx 필드를 추가해서 비교할 수 있게 하면 될까요?

> 파이어스토어 데이터를 불러오는데 시간이 걸려서 화면을 조금 늦게 띄우는 방법이 좋을지요? 다른분들은 어떻게 하셨나요?

> 그 외 빠진 부분이나 잘못된 부분이 있다면 말씀해주세요