### PR TITLE
[#146] Naverlogin 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,9 @@ val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 val kakaoApiKey = localProperties.getProperty("KAKAO_API_KEY")?:""
 val nativeAppKey = localProperties.getProperty("NATIVE_APP_KEY")?:""
+val naverClientId = localProperties.getProperty("NAVER_CLIENT_ID")?:""
+val naverClientSecret = localProperties.getProperty("NAVER_CLIENT_SECRET")?:""
+val naverClientName = localProperties.getProperty("NAVER_CLIENT_NAME")?:""
 
 android {
     namespace = "kr.co.lion.unipiece"
@@ -24,6 +27,9 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "KAKAO_API_KEY", kakaoApiKey)
+        buildConfigField("String", "NAVER_CLIENT_ID", naverClientId)
+        buildConfigField("String", "NAVER_CLIENT_SECRET", naverClientSecret)
+        buildConfigField("String", "NAVER_CLIENT_NAME", naverClientName)
         //manifest에서 사용
         manifestPlaceholders["NATIVE_APP_KEY"] = nativeAppKey
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,4 +86,5 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
 
     implementation("com.kakao.sdk:v2-user:2.20.1")
+    implementation("com.navercorp.nid:oauth:5.9.1") // jdk 11
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -44,6 +44,7 @@ class LoginFragment : Fragment() {
     }
 
 
+
     //버튼 클릭
     private fun settingEvent(){
         fragmentLoginBinding.apply {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -43,6 +43,7 @@ class LoginFragment : Fragment() {
         return fragmentLoginBinding.root
     }
 
+
     //버튼 클릭
     private fun settingEvent(){
         fragmentLoginBinding.apply {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -219,12 +219,6 @@ class LoginFragment : Fragment() {
                         requireActivity().finish()
                     }
                 }
-
-                Log.d("test1234", "아이디 : ${result.profile?.id}") //비번
-                Log.d("test1234", "이메일 : ${result.profile?.email}") //아이디
-                Log.d("test1234", "번호 : ${result.profile?.mobile}") //폰 번호
-                Log.d("test1234", "이름 : ${result.profile?.name}") //이름
-
             }
 
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/login/LoginFragment.kt
@@ -183,15 +183,48 @@ class LoginFragment : Fragment() {
 
             override fun onSuccess(result: NidProfileResponse) {
 
-                Toast.makeText(requireActivity(), "성공", Toast.LENGTH_SHORT).show()
-                Log.d("test1234", "토큰 : ${naverToken}")
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                    checkUserId = viewModel.checkUserId(result.profile?.email?:"")
+
+                    if (checkUserId != false){
+
+                        val dialog = NicknameDialog("닉네임을 입력해주세요")
+                        dialog.setNicknameButtonClickListener(object : NicknameDialog.dialogButtonClickListener{
+                            override fun nicknameOkButton() {
+                                val nickname = dialog.binding.nickNameDialog.text.toString()
+                                val userId = result.profile?.email?:""
+                                val name = result.profile?.name?:""
+                                val phoneNumber = result.profile?.mobile?:""
+                                val userPwd = result.profile?.id?:""
+
+
+                                viewModel.insertUserData(name, nickname, phoneNumber, userId, userPwd,true){success ->
+                                    if (success){
+                                        startActivity(Intent(requireActivity(), MainActivity::class.java))
+                                    }
+                                }
+                            }
+
+                            override fun nicknameNoButton() {
+
+                            }
+
+                        })
+                        dialog.show(parentFragmentManager, "NicknameDialog")
+
+                    }else{
+                        val newIntent = Intent(requireActivity(), MainActivity::class.java)
+                        newIntent.putExtra("userId", result.profile?.email?:"")
+                        startActivity(newIntent)
+                        requireActivity().finish()
+                    }
+                }
+
                 Log.d("test1234", "아이디 : ${result.profile?.id}") //비번
                 Log.d("test1234", "이메일 : ${result.profile?.email}") //아이디
                 Log.d("test1234", "번호 : ${result.profile?.mobile}") //폰 번호
                 Log.d("test1234", "이름 : ${result.profile?.name}") //이름
-                Log.d("test1234", "닉네임 : ${result.profile?.nickname}")
-                Log.d("test1234", "몰라1 : ${result.profile?.ci}")
-                Log.d("test1234", "몰라2 : ${result.profile?.encId}")
+
             }
 
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #146 

## 📝작업 내용

> 네이버 로그인 기능을 구현했습니다
> 아이디 중복 검사를 하여 아이디가 이미 Firestore에 있을 경우 그 아이디로 로그인 하게끔 구현했습니다
> userIdx를 넘기는 작업은 이후에 할 예정입니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
