### PR TITLE
[#154] 작가 리뷰 mvvm 구현 db 연동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
@@ -1,6 +1,7 @@
 package kr.co.lion.unipiece.db.remote
 
 import com.google.firebase.Firebase
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -72,7 +73,7 @@ class AuthorReviewDataSource {
             // AuthorInfo 컬렉션 접근 객체를 가져온다.
             val collectionReference = db.collection("AuthorReview")
             // authorIdx 필드가 매개변수로 들어오는 authorIdx와 같은 문서들을 가져온다.
-            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).get().await()
+            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).orderBy("reviewIdx",Query.Direction.DESCENDING).get().await()
             // 가져온 문서의 수 만큼 반복한다.
             querySnapshot.forEach {
                 val reviewData = it.toObject(AuthorReviewData::class.java)

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
@@ -1,0 +1,100 @@
+package kr.co.lion.unipiece.db.remote
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kr.co.lion.unipiece.model.AuthorReviewData
+
+class AuthorReviewDataSource {
+
+    private val db = Firebase.firestore
+
+    // 리뷰 시퀀스값을 가져온다.
+    suspend fun getReviewSequence():Int{
+
+        var reviewSequence = 0
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 리뷰 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("ReviewSequence")
+            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
+            val documentSnapShot = documentReference.get().await()
+
+            reviewSequence = documentSnapShot.getLong("value")?.toInt()!!
+        }
+        job1.join()
+
+        return reviewSequence
+    }
+
+    // 리뷰 시퀀스 값을 업데이트 한다.
+    suspend fun updateReviewSequence(reviewSequence: Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("ReviewSequence")
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Long>()
+            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
+            map["value"] = reviewSequence.toLong()
+            // 저장한다.
+            documentReference.set(map)
+        }
+        job1.join()
+    }
+
+
+    // 리뷰를 저장한다.
+    suspend fun insertReviewData(authorReviewData: AuthorReviewData){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("AuthorReview")
+            // 컬렉션에 문서를 추가한다.
+            // 문서를 추가할 때 객체나 맵을 지정한다.
+            // 추가된 문서 내부의 필드는 객체가 가진 프로퍼티의 이름이나 맵에 있는 데이터의 이름으로 동일하게 결정된다.
+            collectionReference.add(authorReviewData)
+        }
+        job1.join()
+    }
+
+    // 작가idx를 통해 리뷰를 가져와 반환한다
+    suspend fun getAuthorReviewDataByIdx(authorIdx:Int) : MutableList<AuthorReviewData> {
+
+        val reviewList = mutableListOf<AuthorReviewData>()
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // AuthorInfo 컬렉션 접근 객체를 가져온다.
+            val collectionReference = db.collection("AuthorReview")
+            // authorIdx 필드가 매개변수로 들어오는 authorIdx와 같은 문서들을 가져온다.
+            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).get().await()
+            // 가져온 문서의 수 만큼 반복한다.
+            querySnapshot.forEach {
+                val reviewData = it.toObject(AuthorReviewData::class.java)
+                reviewList.add(reviewData)
+            }
+        }
+        job1.join()
+
+        return reviewList
+    }
+
+    // 리뷰idx를 통해 리뷰를 삭제한다.
+    suspend fun deleteReview(reviewIdx:Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("AuthorReview")
+            // reviewIdx 필드가 매개변수로 들어오는 reviewIdx와 같은 문서를 가져온다.
+            val querySnapshot = collectionReference.whereEqualTo("reviewIdx", reviewIdx).get().await()
+            val documentReference = querySnapshot.documents[0].reference
+            documentReference.delete()
+        }
+        job1.join()
+    }
+
+}

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorReviewDataSource.kt
@@ -73,7 +73,7 @@ class AuthorReviewDataSource {
             // AuthorInfo 컬렉션 접근 객체를 가져온다.
             val collectionReference = db.collection("AuthorReview")
             // authorIdx 필드가 매개변수로 들어오는 authorIdx와 같은 문서들을 가져온다.
-            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).orderBy("reviewIdx",Query.Direction.DESCENDING).get().await()
+            val querySnapshot = collectionReference.whereEqualTo("authorIdx", authorIdx).orderBy("reviewTime",Query.Direction.DESCENDING).get().await()
             // 가져온 문서의 수 만큼 반복한다.
             querySnapshot.forEach {
                 val reviewData = it.toObject(AuthorReviewData::class.java)

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorReviewData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorReviewData.kt
@@ -5,9 +5,10 @@ import com.google.firebase.Timestamp
 data class AuthorReviewData(
     val reviewIdx: Int,
     val userIdx: Int,
+    val userNickname: String,
     val authorIdx: Int,
     val reviewContent: String,
     val reviewTime: Timestamp,
 ){
-    constructor() : this(0, 0, 0, "멋진 리뷰", Timestamp.now())
+    constructor() : this(0, 0, "닉네임", 0, "멋진 리뷰", Timestamp.now())
 }

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorReviewData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorReviewData.kt
@@ -1,0 +1,13 @@
+package kr.co.lion.unipiece.model
+
+import com.google.firebase.Timestamp
+
+data class AuthorReviewData(
+    val reviewIdx: Int,
+    val userIdx: Int,
+    val authorIdx: Int,
+    val reviewContent: String,
+    val reviewTime: Timestamp,
+){
+    constructor() : this(0, 0, 0, "멋진 리뷰", Timestamp.now())
+}

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorReviewRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorReviewRepository.kt
@@ -1,0 +1,29 @@
+package kr.co.lion.unipiece.repository
+
+import kr.co.lion.unipiece.db.remote.AuthorReviewDataSource
+import kr.co.lion.unipiece.model.AuthorReviewData
+
+class AuthorReviewRepository {
+    private val authorReviewDataSource = AuthorReviewDataSource()
+
+    // 리뷰 시퀀스값을 가져온다.
+    suspend fun getReviewSequence() =
+        authorReviewDataSource.getReviewSequence()
+
+    // 리뷰 시퀀스 값을 업데이트 한다.
+    suspend fun updateReviewSequence(reviewSequence: Int) =
+        authorReviewDataSource.updateReviewSequence(reviewSequence)
+
+    // 리뷰를 저장한다.
+    suspend fun insertReviewData(authorReviewData: AuthorReviewData) =
+        authorReviewDataSource.insertReviewData(authorReviewData)
+
+    // 작가idx를 통해 리뷰를 가져와 반환한다
+    suspend fun getAuthorReviewDataByIdx(authorIdx:Int) : MutableList<AuthorReviewData> =
+        authorReviewDataSource.getAuthorReviewDataByIdx(authorIdx)
+
+    // 리뷰idx를 통해 리뷰를 삭제한다.
+    suspend fun deleteReview(reviewIdx:Int) =
+        authorReviewDataSource.deleteReview(reviewIdx)
+
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
@@ -27,7 +27,7 @@ class AuthorInfoActivity : AppCompatActivity() {
         // 이전 액티비티에서 authorIdx와 userIdx를 받아온다.
         // 수정 필요
         authorInfoBundle.putInt("authorIdx",1)
-        authorInfoBundle.putInt("userIdx",2)
+        authorInfoBundle.putInt("userIdx",9)
 
         replaceFragment(AuthorInfoFragmentName.AUTHOR_INFO_FRAGMENT, false, authorInfoBundle)
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -20,6 +20,7 @@ import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
+import kr.co.lion.unipiece.ui.author.viewmodel.AuthorInfoViewModel
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 import kr.co.lion.unipiece.util.setMenuIconColor

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorReviewBottomSheetBinding
 import kr.co.lion.unipiece.model.AuthorReviewData
+import kr.co.lion.unipiece.repository.UserInfoRepository
 import kr.co.lion.unipiece.ui.author.adapter.AuthorReviewAdapter
 import kr.co.lion.unipiece.ui.author.viewmodel.AuthorReviewViewModel
 
@@ -34,6 +35,7 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
     val userIdx by lazy {
         requireArguments().getInt("userIdx")
     }
+
     val authorIdx by lazy {
         requireArguments().getInt("authorIdx")
     }
@@ -102,7 +104,6 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
             addReview()
             false
         }
-
     }
 
     private fun addReview(){
@@ -112,9 +113,10 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
                 val reviewSequence = authorReviewViewModel.getReviewSequence() + 1
 
                 val userIdx = userIdx
+                val userNickname = UserInfoRepository().getUserDataByIdx(userIdx)?.nickName.toString()
                 val authorIdx = authorIdx
                 val reviewTime = Timestamp.now()
-                val reviewData = AuthorReviewData(reviewSequence, userIdx, authorIdx, reviewContent, reviewTime)
+                val reviewData = AuthorReviewData(reviewSequence, userIdx, userNickname, authorIdx, reviewContent, reviewTime)
 
                 // 작성 내용 저장
                 authorReviewViewModel.insertReviewData(reviewData)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -6,7 +6,8 @@ import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
+import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -23,7 +24,7 @@ import kr.co.lion.unipiece.databinding.FragmentAuthorReviewBottomSheetBinding
 import kr.co.lion.unipiece.model.AuthorReviewData
 import kr.co.lion.unipiece.ui.author.adapter.AuthorReviewAdapter
 import kr.co.lion.unipiece.ui.author.viewmodel.AuthorReviewViewModel
-import kr.co.lion.unipiece.util.hideSoftInput
+
 
 class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
 
@@ -36,7 +37,6 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
     val authorIdx by lazy {
         requireArguments().getInt("authorIdx")
     }
-
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -96,7 +96,6 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
     private fun settingButtonAuthorReviewAdd(){
         fragmentAuthorReviewBottomSheetBinding.buttonAuthorReviewAdd.setOnClickListener {
             addReview()
-            requireActivity().hideSoftInput()
         }
 
         fragmentAuthorReviewBottomSheetBinding.textInputAuthorReview.setOnEditorActionListener { textView, i, keyEvent ->
@@ -125,7 +124,8 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
                 authorReviewViewModel.getReviewList(authorIdx)
                 // 입력칸 초기화
                 authorReviewViewModel.authorReviewContent.value = ""
-                Toast.makeText(requireActivity(), "작성 완료", Toast.LENGTH_SHORT).show()
+                // 키보드 내리기
+                rHideSoftInput()
             }
         }
     }
@@ -146,7 +146,7 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     // BottomSheet의 높이를 설정해준다.
-    fun setBottomSheetHeight(bottomSheetDialog: BottomSheetDialog){
+    private fun setBottomSheetHeight(bottomSheetDialog: BottomSheetDialog){
         // BottomSheet의 기본 뷰 객체를 가져온다
         val bottomSheet = bottomSheetDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)!!
         // BottomSheet 높이를 설정할 수 있는 객체를 생성한다.
@@ -160,12 +160,12 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     // BottomSheet의 높이를 구한다(화면 액정의 85% 크기)
-    fun getBottomSheetDialogHeight() : Int{
+    private fun getBottomSheetDialogHeight() : Int{
         return (getWindowHeight() * 0.7).toInt()
     }
 
     // 사용자 단말기 액정의 길이를 구해 반환하는 메서드
-    fun getWindowHeight() : Int {
+    private fun getWindowHeight() : Int {
         // 화면 크기 정보를 담을 배열 객체
         val displayMetrics = DisplayMetrics()
         // 액정의 가로/세로 길이 정보를 담아준다.
@@ -173,4 +173,15 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
         // 세로 길이를 반환해준다.
         return displayMetrics.heightPixels
     }
+
+    private fun rHideSoftInput(){
+        // KeyBoardUtil.kt의 hideSoftInput()는 BottomSheetDialog 에서 안되는 것 같음
+        // requireActivity().window.currentFocus 값이 null로 나옴
+        // https://stackoverflow.com/questions/66219617/how-to-hide-soft-key-in-bottom-sheet-dialog-in-android 참고함
+        view?.clearFocus()
+        val rInputMethodManager = requireActivity().getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE) as InputMethodManager
+        rInputMethodManager.hideSoftInputFromWindow(view?.windowToken, 0)
+    }
+
 }
+

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -1,6 +1,8 @@
 package kr.co.lion.unipiece.ui.author
 
+import android.app.Dialog
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +11,8 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.firebase.Timestamp
@@ -124,5 +128,49 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
                 Toast.makeText(requireActivity(), "작성 완료", Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    // 다이얼로그가 만들어질 때 자동으로 호출되는 메서드
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        // 다이얼로그를 받는다.
+        val dialog = super.onCreateDialog(savedInstanceState)
+        // 다이얼로그가 보일 때 동작하는 리스너
+        dialog.setOnShowListener {
+
+            val bottomSheetDialog = it as BottomSheetDialog
+            // 높이를 설정한다.
+            setBottomSheetHeight(bottomSheetDialog)
+        }
+
+        return dialog
+    }
+
+    // BottomSheet의 높이를 설정해준다.
+    fun setBottomSheetHeight(bottomSheetDialog: BottomSheetDialog){
+        // BottomSheet의 기본 뷰 객체를 가져온다
+        val bottomSheet = bottomSheetDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)!!
+        // BottomSheet 높이를 설정할 수 있는 객체를 생성한다.
+        val behavior = BottomSheetBehavior.from(bottomSheet)
+        // 높이를 설정한다.
+        val layoutParams = bottomSheet.layoutParams
+        layoutParams.height = getBottomSheetDialogHeight()
+        bottomSheet.layoutParams = layoutParams
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+    }
+
+    // BottomSheet의 높이를 구한다(화면 액정의 85% 크기)
+    fun getBottomSheetDialogHeight() : Int{
+        return (getWindowHeight() * 0.7).toInt()
+    }
+
+    // 사용자 단말기 액정의 길이를 구해 반환하는 메서드
+    fun getWindowHeight() : Int {
+        // 화면 크기 정보를 담을 배열 객체
+        val displayMetrics = DisplayMetrics()
+        // 액정의 가로/세로 길이 정보를 담아준다.
+        requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
+        // 세로 길이를 반환해준다.
+        return displayMetrics.heightPixels
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -1,36 +1,50 @@
 package kr.co.lion.unipiece.ui.author
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
+import android.widget.Toast
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.divider.MaterialDividerItemDecoration
+import com.google.firebase.Timestamp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentAuthorReviewBottomSheetBinding
-import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
-import kr.co.lion.unipiece.databinding.RowAuthorReviewBottomSheetBinding
-import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
+import kr.co.lion.unipiece.model.AuthorReviewData
 import kr.co.lion.unipiece.ui.author.adapter.AuthorReviewAdapter
+import kr.co.lion.unipiece.ui.author.viewmodel.AuthorReviewViewModel
+import kr.co.lion.unipiece.util.hideSoftInput
 
 class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
 
     lateinit var fragmentAuthorReviewBottomSheetBinding: FragmentAuthorReviewBottomSheetBinding
-    lateinit var reviewAdapter: AuthorReviewAdapter
+    private val authorReviewViewModel:AuthorReviewViewModel by viewModels()
+
+    val userIdx by lazy {
+        requireArguments().getInt("userIdx")
+    }
+    val authorIdx by lazy {
+        requireArguments().getInt("authorIdx")
+    }
+
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        fragmentAuthorReviewBottomSheetBinding = FragmentAuthorReviewBottomSheetBinding.inflate(inflater)
+        fragmentAuthorReviewBottomSheetBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_author_review_bottom_sheet, container, false)
+        fragmentAuthorReviewBottomSheetBinding.authorReviewViewModel = authorReviewViewModel
+        fragmentAuthorReviewBottomSheetBinding.lifecycleOwner = this
 
         settingButtonAuthorReviewAdd()
-        
+
         return fragmentAuthorReviewBottomSheetBinding.root
     }
 
@@ -42,23 +56,33 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
 
     // 리사이클러 뷰 셋팅
     private fun settingRecyclerView(){
-        // 테스트 데이터
-        val reviewList = arrayListOf<Any>(
-            "test","test","test","test","test","test","test","test","test","test"
-        )
+        lifecycleScope.launch(Dispatchers.Main) {
+            authorReviewViewModel.getReviewList(authorIdx)
+            authorReviewViewModel.authorReviewList.observe(viewLifecycleOwner) { value ->
+                val reviewAdapter =
+                    AuthorReviewAdapter(userIdx, value, deleteListener = { reviewIdx ->
+                        lifecycleScope.launch(Dispatchers.IO){
+                            // 리뷰 삭제
+                            authorReviewViewModel.deleteReview(reviewIdx)
+                            // 시퀀스 값 업데이트
+                            val reviewSequence = authorReviewViewModel.getReviewSequence() -1
+                            authorReviewViewModel.updateReviewSequence(reviewSequence)
+                            // 리뷰 정보 다시 불러오기
+                            authorReviewViewModel.getReviewList(authorIdx)
+                        }
+                    })
 
-        // 리사이클러뷰 어댑터
-        reviewAdapter = AuthorReviewAdapter(reviewList)
-
-        // 리사이클러뷰 셋팅
-        fragmentAuthorReviewBottomSheetBinding.recyclerViewAuthorReview.apply {
-            // 어댑터
-            adapter = reviewAdapter
-            // 레이아웃 매니저, 가로 방향 셋팅
-            layoutManager = LinearLayoutManager(requireActivity())
-            // 데코레이션
-            val deco = MaterialDividerItemDecoration(requireActivity(), MaterialDividerItemDecoration.VERTICAL)
-            addItemDecoration(deco)
+                // 리사이클러뷰 셋팅
+                fragmentAuthorReviewBottomSheetBinding.recyclerViewAuthorReview.apply {
+                    // 어댑터
+                    adapter = reviewAdapter
+                    // 레이아웃 매니저, 가로 방향 셋팅
+                    layoutManager = LinearLayoutManager(requireActivity())
+                    // 데코레이션
+                    val deco = MaterialDividerItemDecoration(requireActivity(), MaterialDividerItemDecoration.VERTICAL)
+                    addItemDecoration(deco)
+                }
+            }
         }
     }
 
@@ -66,8 +90,39 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
 
     // 확인 버튼
     private fun settingButtonAuthorReviewAdd(){
-        // 작성 내용 체크
-        
-        // 작성 내용 저장
+        fragmentAuthorReviewBottomSheetBinding.buttonAuthorReviewAdd.setOnClickListener {
+            addReview()
+            requireActivity().hideSoftInput()
+        }
+
+        fragmentAuthorReviewBottomSheetBinding.textInputAuthorReview.setOnEditorActionListener { textView, i, keyEvent ->
+            addReview()
+            false
+        }
+
+    }
+
+    private fun addReview(){
+        val reviewContent = authorReviewViewModel.authorReviewContent.value
+        if(reviewContent!!.isNotEmpty()){
+            lifecycleScope.launch {
+                val reviewSequence = authorReviewViewModel.getReviewSequence() + 1
+
+                val userIdx = userIdx
+                val authorIdx = authorIdx
+                val reviewTime = Timestamp.now()
+                val reviewData = AuthorReviewData(reviewSequence, userIdx, authorIdx, reviewContent, reviewTime)
+
+                // 작성 내용 저장
+                authorReviewViewModel.insertReviewData(reviewData)
+                // 시퀀스 값 업데이트
+                authorReviewViewModel.updateReviewSequence(reviewSequence)
+                // 리뷰 정보 다시 가져오기
+                authorReviewViewModel.getReviewList(authorIdx)
+                // 입력칸 초기화
+                authorReviewViewModel.authorReviewContent.value = ""
+                Toast.makeText(requireActivity(), "작성 완료", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
@@ -21,7 +21,7 @@ class AuthorReviewAdapter(val userIdx:Int, val reviewList: List<AuthorReviewData
 
     override fun onBindViewHolder(holder: AuthorReviewViewHolder, position: Int) {
         // 닉네임
-        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = reviewList[position].userIdx.toString()
+        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = reviewList[position].userNickname
         // 댓글 내용
         holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewText.text = reviewList[position].reviewContent
         // 삭제 버튼은 본인 댓글만 보여지게

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorReviewAdapter.kt
@@ -5,8 +5,9 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.databinding.RowAuthorReviewBottomSheetBinding
+import kr.co.lion.unipiece.model.AuthorReviewData
 
-class AuthorReviewAdapter(val reviewList: ArrayList<Any>): RecyclerView.Adapter<AuthorReviewViewHolder>() {
+class AuthorReviewAdapter(val userIdx:Int, val reviewList: List<AuthorReviewData>, private val deleteListener: (reviewIdx: Int) -> Unit): RecyclerView.Adapter<AuthorReviewViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuthorReviewViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val rowAuthorReviewBottomSheetBinding = RowAuthorReviewBottomSheetBinding.inflate(inflater)
@@ -15,20 +16,25 @@ class AuthorReviewAdapter(val reviewList: ArrayList<Any>): RecyclerView.Adapter<
     }
 
     override fun getItemCount(): Int {
-        return 20
+        return reviewList.size
     }
 
     override fun onBindViewHolder(holder: AuthorReviewViewHolder, position: Int) {
         // 닉네임
-        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = "김토끼 $position"
+        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewNickName.text = reviewList[position].userIdx.toString()
         // 댓글 내용
-        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewText.text = "홍작가님 작품 너무 대박이에요"
+        holder.rowAuthorReviewBottomSheetBinding.textViewRowAuthorReviewText.text = reviewList[position].reviewContent
         // 삭제 버튼은 본인 댓글만 보여지게
-        if(true){
+        if(reviewList[position].userIdx == userIdx){
             holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = true
         }else{
             holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.isVisible = false
         }
+
+        holder.rowAuthorReviewBottomSheetBinding.buttonRowAuthorReviewDelete.setOnClickListener {
+            deleteListener(reviewList[position].reviewIdx)
+        }
+
     }
 }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorInfoViewModel.kt
@@ -1,4 +1,4 @@
-package kr.co.lion.unipiece.ui.author
+package kr.co.lion.unipiece.ui.author.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
@@ -14,6 +14,26 @@ class AuthorReviewViewModel : ViewModel() {
     private val _authorReviewList = MutableLiveData<List<AuthorReviewData>>()
     val authorReviewList: LiveData<List<AuthorReviewData>> = _authorReviewList
 
+    // 댓글 내용
+    val authorReviewContent = MutableLiveData<String>()
+
+    // 리뷰 시퀀스 값 가져오기
+    suspend fun getReviewSequence(): Int {
+        var sequence = 0
+        val job1 = viewModelScope.launch {
+            sequence = authorReviewRepository.getReviewSequence()
+        }
+        job1.join()
+        return sequence
+    }
+
+    // 리뷰 시퀀스 값 업데이트
+    suspend fun updateReviewSequence(reviewSequence: Int){
+        val job1 = viewModelScope.launch {
+            authorReviewRepository.updateReviewSequence(reviewSequence+1)
+        }
+        job1.join()
+    }
     // 리뷰 등록
     suspend fun insertReviewData(authorReviewData: AuthorReviewData){
         val job1 = viewModelScope.launch {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
@@ -30,7 +30,7 @@ class AuthorReviewViewModel : ViewModel() {
     // 리뷰 시퀀스 값 업데이트
     suspend fun updateReviewSequence(reviewSequence: Int){
         val job1 = viewModelScope.launch {
-            authorReviewRepository.updateReviewSequence(reviewSequence+1)
+            authorReviewRepository.updateReviewSequence(reviewSequence)
         }
         job1.join()
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorReviewViewModel.kt
@@ -1,0 +1,39 @@
+package kr.co.lion.unipiece.ui.author.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.model.AuthorReviewData
+import kr.co.lion.unipiece.repository.AuthorReviewRepository
+
+class AuthorReviewViewModel : ViewModel() {
+    private val authorReviewRepository = AuthorReviewRepository()
+
+    private val _authorReviewList = MutableLiveData<List<AuthorReviewData>>()
+    val authorReviewList: LiveData<List<AuthorReviewData>> = _authorReviewList
+
+    // 리뷰 등록
+    suspend fun insertReviewData(authorReviewData: AuthorReviewData){
+        val job1 = viewModelScope.launch {
+            authorReviewRepository.insertReviewData(authorReviewData)
+        }
+        job1.join()
+    }
+
+    // 리뷰 불러오기
+    suspend fun getReviewList(authorIdx:Int){
+        val job1 = viewModelScope.launch {
+            _authorReviewList.value = authorReviewRepository.getAuthorReviewDataByIdx(authorIdx)
+        }
+        job1.join()
+    }
+
+    // 리뷰 삭제
+    suspend fun deleteReview(reviewIdx:Int){
+        val job1 = viewModelScope.launch {
+            authorReviewRepository.deleteReview(reviewIdx)
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_author_info.xml
+++ b/app/src/main/res/layout/fragment_author_info.xml
@@ -7,7 +7,7 @@
     <data>
         <variable
             name="authorInfoViewModel"
-            type="kr.co.lion.unipiece.ui.author.AuthorInfoViewModel" />
+            type="kr.co.lion.unipiece.ui.author.viewmodel.AuthorInfoViewModel" />
     </data>
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_author_review_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_author_review_bottom_sheet.xml
@@ -15,11 +15,6 @@
         android:padding="20dp"
         tools:context=".ui.author.AuthorReviewBottomSheetFragment">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerViewAuthorReview"
-            android:layout_width="match_parent"
-            android:layout_height="300dp" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -61,6 +56,11 @@
                 android:textColor="@color/white"
                 android:textStyle="bold" />
         </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewAuthorReview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_author_review_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_author_review_bottom_sheet.xml
@@ -1,57 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="20dp"
-    tools:context=".ui.author.AuthorReviewBottomSheetFragment">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerViewAuthorReview"
-        android:layout_width="match_parent"
-        android:layout_height="300dp" />
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <variable
+            name="authorReviewViewModel"
+            type="kr.co.lion.unipiece.ui.author.viewmodel.AuthorReviewViewModel" />
+    </data>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:gravity="center"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:padding="20dp"
+        tools:context=".ui.author.AuthorReviewBottomSheetFragment">
 
-        <com.google.android.material.textfield.TextInputLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewAuthorReview"
+            android:layout_width="match_parent"
+            android:layout_height="300dp" />
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="2"
-            android:hint="리뷰를 작성해주세요"
-            app:boxStrokeColor="@color/second"
-            app:cursorColor="@color/second"
-            app:hintTextColor="@color/second">
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:orientation="horizontal">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/textInputAuthorReview"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:layout_marginBottom="12dp"
-                android:background="@drawable/textfield_radius"
-                android:inputType="text"
-                android:paddingLeft="10dp"
-                android:textSize="14sp" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:hint="리뷰를 작성해주세요"
+                app:boxStrokeColor="@color/second"
+                app:cursorColor="@color/second"
+                app:hintTextColor="@color/second">
 
-        <Button
-            android:id="@+id/buttonAuthorReviewAdd"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:layout_weight="1"
-            android:background="@drawable/button_radius"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:text="확인"
-            android:textColor="@color/white"
-            android:textStyle="bold" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/textInputAuthorReview"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:layout_marginBottom="12dp"
+                    android:background="@drawable/textfield_radius"
+                    android:inputType="text"
+                    android:paddingLeft="10dp"
+                    android:textSize="14sp"
+                    android:text="@={authorReviewViewModel.authorReviewContent}"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/buttonAuthorReviewAdd"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:layout_weight="1"
+                android:background="@drawable/button_radius"
+                android:paddingLeft="5dp"
+                android:paddingRight="5dp"
+                android:text="확인"
+                android:textColor="@color/white"
+                android:textStyle="bold" />
+        </LinearLayout>
+
     </LinearLayout>
-
-</LinearLayout>
+</layout>

--- a/app/src/main/res/layout/row_author_review_bottom_sheet.xml
+++ b/app/src/main/res/layout/row_author_review_bottom_sheet.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
+        android:minHeight="48dp"
         android:orientation="horizontal">
 
         <TextView


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

> 작가 리뷰 mvvm 구조로 변경 및 db 연동
> 리뷰 등록 시 닉네임도 필드로 추가하여 리뷰 불러올 때 닉네임도 같이 불러올 수 있도록 했습니다
> 리뷰 등록 시간순서(내림차순)으로 정렬했습니다.
> 입력칸을 리사이클러뷰 위로 옮겼습니다
> BottomSheetDialog에서는 KeyBoardUtil의 hideSoftInput()이 작동하지 않아서 따로 메서드를 다시 구현했습니다

### 스크린샷 (선택)
[authorreview.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/8bd31a40-dae4-47ae-97d8-3d66c51a1d58)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> hideSoftInput메서드가 BottomSheetDialog에서는 제대로 실행이 안되는것 같아 확인해보니  window.currentFocus 값이 null로 나오길래 아래 링크 참고해서 view를 전달하는걸로 메서드를 따로 만들었습니다.
> 혹시 접근방법이 잘못된거라면 말씀 부탁드리겠습니다.
> https://stackoverflow.com/questions/66219617/how-to-hide-soft-key-in-bottom-sheet-dialog-in-android
