### PR TITLE
[#134] 주문하기 및 팔로우 리사이클러뷰 분리 및 장바구니 mvvm 구현 db연동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/CartDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/CartDataSource.kt
@@ -1,38 +1,5 @@
 package kr.co.lion.unipiece.db.remote
 
-import com.google.firebase.Firebase
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.firestore
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import kr.co.lion.unipiece.model.CartData
-import kr.co.lion.unipiece.model.PieceInfoData
-
 class CartDataSource {
-
-    private val db = Firebase.firestore
-
-
-
-    // 작품의 idx값을 가지고 작품의 정보 가져오기
-    suspend fun getPieceDataByIdx(pieceIdx:Int) : MutableList<PieceInfoData>{
-        val pieceInfoDataList = mutableListOf<PieceInfoData>()
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 작품 정보 컬렉션에 접근
-            val collectionReference = db.collection("PieceInfo")
-            // pieceIdx 필드가 매개변수로 들어오는 pieceIdx와 같은 문서들을 가져온다.
-            val querySnapshot = collectionReference.whereEqualTo("pieceIdx", pieceIdx).get().await()
-            // 가져온 문서의 수만큼 반복한다.
-            querySnapshot.forEach {
-                val pieceInfoData = it.toObject(PieceInfoData::class.java)
-                pieceInfoDataList.add(pieceInfoData)
-            }
-        }
-        job1.join()
-
-        return pieceInfoDataList
-    }
 
 }

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/CartDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/CartDataSource.kt
@@ -1,0 +1,79 @@
+package kr.co.lion.unipiece.db.remote
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kr.co.lion.unipiece.model.UserInfoData
+
+class CartDataSource {
+
+    private val db = Firebase.firestore
+
+
+    // 유저 시퀀스
+    suspend fun getCartSequence():Int{
+        //값 초기화
+        var cartSequence = 0
+
+        var job1 = CoroutineScope(Dispatchers.IO).launch {
+            //컬렉션에 접근
+            val collectionReference = db.collection("Sequence")
+            //문서에 접근
+            val documentReference = collectionReference.document("UserSequence")
+            //문서 내에 있는 데이터를 가져올 객체를 가져온다
+            val documentSnapshot = documentReference.get().await()
+
+            cartSequence = documentSnapshot.getLong("value")?.toInt()?: -1
+
+        }
+        job1.join()
+        return cartSequence
+    }
+
+    //시퀀스 업데이트
+    suspend fun updateCartSequence(cartSequence:Int){
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            val collectionReference = db.collection("Sequence")
+            val documentReference = collectionReference.document("CartSequence")
+            val map = mutableMapOf<String, Long>()
+            map["value"] = cartSequence.toLong()
+            documentReference.set(map)
+        }
+        job1.join()
+    }
+
+    // 작품의 idx값을 가지고 작품의 정보 가져오기
+    suspend fun getPieceDataByIdx(userIdx:Int) : UserInfoData?{
+        var userInfoData: UserInfoData? = null
+
+        var job1 = CoroutineScope(Dispatchers.IO).launch {
+            val collectionReference = db.collection("UserInfo")
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+            if (querySnapshot.isEmpty == false){
+                userInfoData = querySnapshot.documents[0].toObject(UserInfoData::class.java)
+            }
+        }
+        job1.join()
+
+        return userInfoData
+    }
+
+    //유저의 idx값을 가지고 유저의 정보 가져오기
+    suspend fun getUserDataByIdx(userIdx:Int) : UserInfoData?{
+        var userInfoData:UserInfoData? = null
+
+        var job1 = CoroutineScope(Dispatchers.IO).launch {
+            val collectionReference = db.collection("UserInfo")
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+            if (querySnapshot.isEmpty == false){
+                userInfoData = querySnapshot.documents[0].toObject(UserInfoData::class.java)
+            }
+        }
+        job1.join()
+
+        return userInfoData
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
@@ -1,0 +1,137 @@
+package kr.co.lion.unipiece.db.remote
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kr.co.lion.unipiece.model.DeliveryData
+
+class DeliveryDataSource {
+
+    private val db = Firebase.firestore
+
+    // 배송지 시퀀스값을 가져온다.
+    suspend fun getDeliverySequence(): Int {
+
+        var deliverySequence = -1
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 사용자 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("DeliverySequence")
+            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
+            val documentSnapShot = documentReference.get().await()
+
+            deliverySequence = documentSnapShot.getLong("value")?.toInt() ?: -1
+        }
+        job1.join()
+
+        return deliverySequence
+    }
+
+    // 배송지 시퀀스 값을 업데이트 한다.
+    suspend fun updateDeliverySequence(authorSequence: Int) {
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Sequence")
+            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+            val documentReference = collectionReference.document("DeliverySequence")
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Long>()
+            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
+            map["value"] = authorSequence.toLong()
+            // 저장한다.
+            documentReference.set(map)
+        }
+        job1.join()
+    }
+
+    // 배송지 정보를 저장한다.
+    suspend fun insertDeliveryData(deliveryData: DeliveryData) {
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Delivery")
+            // 컬렉션에 문서를 추가한다.
+            // 문서를 추가할 때 객체나 맵을 지정한다.
+            // 추가된 문서 내부의 필드는 객체가 가진 프로퍼티의 이름이나 맵에 있는 데이터의 이름으로 동일하게 결정된다.
+            collectionReference.add(deliveryData)
+        }
+        job1.join()
+    }
+
+    // UserIdx 를 통해 배송지 정보를 가져와 반환한다
+    suspend fun getDeliveryDataByIdx(userIdx: Int): DeliveryData? {
+        // 배송지 정보를 담을 프로퍼티
+        var userDeliveryData: DeliveryData? = null
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // Delivery 컬렉션 접근 객체를 가져온다.
+            val collectionReference = db.collection("Delivery")
+            // userIdx 필드가 매개변수로 들어오는 userIdx와 같은 문서들을 가져온다.
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
+            // 회원 번호가 동일한 사용는 없기 때문에 무조건 하나만 나오기 때문이다
+            userDeliveryData = querySnapshot.documents[0].toObject(DeliveryData::class.java)
+        }
+        job1.join()
+
+        return userDeliveryData
+    }
+
+    // 모든 작가의 정보를 가져온다.
+    suspend fun getDeliveryAll(): MutableList<DeliveryData> {
+        // 사용자 정보를 담을 리스트
+        val deliveryList = mutableListOf<DeliveryData>()
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 모든 사용자 정보를 가져온다.
+            val querySnapshot = db.collection("Delivery").get().await()
+            // 가져온 문서의 수 만큼 반복한다.
+            querySnapshot.forEach {
+                // UserModel 객체에 담는다.
+                val deliveryData = it.toObject(DeliveryData::class.java)
+                // 리스트에 담는다.
+                deliveryList.add(deliveryData)
+            }
+        }
+        job1.join()
+
+        return deliveryList
+    }
+
+    // 배송지 정보를 수정하는 메서드
+    suspend fun updateDeliveryData(deliveryData: DeliveryData) {
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+            val collectionReference = db.collection("Delivery")
+
+            // 컬렉션이 가지고 있는 문서들 중에 수정할 작가 정보를 가져온다.
+            val query =
+                collectionReference.whereEqualTo("deliveryIdx", deliveryData.deliveryIdx).get()
+                    .await()
+
+            // 저장할 데이터를 담을 HashMap을 만들어준다.
+            val map = mutableMapOf<String, Any?>()
+            // 받는 이
+            map["deliveryName"] = deliveryData.deliveryName
+            // 연락처
+            map["deliveryPhone"] = deliveryData.deliveryPhone
+            // 배송지 명(별명)
+            map["deliveryNicName"] = deliveryData.deliveryNickName
+            // 주소
+            map["deliveryAddress"] = deliveryData.deliveryAddress
+            // 배송 메모
+            map["deliveryMemo"] = deliveryData.deliveryMemo
+            // 기본배송지 여부
+            map["basicDelivery"] = deliveryData.basicDelivery
+
+            // 저장한다.
+            // 가져온 문서 중 첫 번째 문서에 접근하여 데이터를 수정한다.
+            query.documents[0].reference.update(map)
+        }
+        job1.join()
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
@@ -1,137 +1,162 @@
 package kr.co.lion.unipiece.db.remote
 
+import android.util.Log
 import com.google.firebase.Firebase
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.firestore
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kr.co.lion.unipiece.model.DeliveryData
 
 class DeliveryDataSource {
 
-    private val db = Firebase.firestore
+    private val deliveryStore = Firebase.firestore.collection("Delivery")
 
-    // 배송지 시퀀스값을 가져온다.
-    suspend fun getDeliverySequence(): Int {
+    //    // 배송지 시퀀스값을 가져온다.
+//    suspend fun getDeliverySequence(): Int {
+//
+//        var deliverySequence = -1
+//
+//        val job1 = CoroutineScope(Dispatchers.IO).launch {
+//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+//            val collectionReference = db.collection("Sequence")
+//            // 사용자 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+//            val documentReference = collectionReference.document("DeliverySequence")
+//            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
+//            val documentSnapShot = documentReference.get().await()
+//
+//            deliverySequence = documentSnapShot.getLong("value")?.toInt() ?: -1
+//        }
+//        job1.join()
+//
+//        return deliverySequence
+//    }
+//
+//    // 배송지 시퀀스 값을 업데이트 한다.
+//    suspend fun updateDeliverySequence(authorSequence: Int) {
+//        val job1 = CoroutineScope(Dispatchers.IO).launch {
+//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+//            val collectionReference = db.collection("Sequence")
+//            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
+//            val documentReference = collectionReference.document("DeliverySequence")
+//            // 저장할 데이터를 담을 HashMap을 만들어준다.
+//            val map = mutableMapOf<String, Long>()
+//            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
+//            map["value"] = authorSequence.toLong()
+//            // 저장한다.
+//            documentReference.set(map)
+//        }
+//        job1.join()
+//    }
+//
+    // 신규 배송지 등록
+    suspend fun insertDeliveryData(deliveryData: DeliveryData): Boolean {
+        return try {
+            val deliveryId = deliveryStore.document().id
 
-        var deliverySequence = -1
+            val deliveryDataMap = hashMapOf(
+                "deliveryName" to deliveryData.deliveryName,
+                "deliveryAddress" to deliveryData.deliveryAddress,
+                "deliveryPhone" to deliveryData.deliveryPhone,
+                "deliveryNickName" to deliveryData.deliveryNickName,
+                "deliveryMemo" to deliveryData.deliveryMemo,
+                "basicDelivery" to deliveryData.basicDelivery,
+                "deliveryIdx" to deliveryData.deliveryIdx,
+                "userIdx" to deliveryData.userIdx,
+            )
 
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-            val collectionReference = db.collection("Sequence")
-            // 사용자 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
-            val documentReference = collectionReference.document("DeliverySequence")
-            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
-            val documentSnapShot = documentReference.get().await()
+            // 작품 정보 저장
+            deliveryStore
+                .document(deliveryId)
+                .set(deliveryDataMap)
+                .await()
 
-            deliverySequence = documentSnapShot.getLong("value")?.toInt() ?: -1
+            true
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error insertDeliveryData : ${e.message}")
+            return false
         }
-        job1.join()
-
-        return deliverySequence
-    }
-
-    // 배송지 시퀀스 값을 업데이트 한다.
-    suspend fun updateDeliverySequence(authorSequence: Int) {
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-            val collectionReference = db.collection("Sequence")
-            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
-            val documentReference = collectionReference.document("DeliverySequence")
-            // 저장할 데이터를 담을 HashMap을 만들어준다.
-            val map = mutableMapOf<String, Long>()
-            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
-            map["value"] = authorSequence.toLong()
-            // 저장한다.
-            documentReference.set(map)
-        }
-        job1.join()
-    }
-
-    // 배송지 정보를 저장한다.
-    suspend fun insertDeliveryData(deliveryData: DeliveryData) {
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-            val collectionReference = db.collection("Delivery")
-            // 컬렉션에 문서를 추가한다.
-            // 문서를 추가할 때 객체나 맵을 지정한다.
-            // 추가된 문서 내부의 필드는 객체가 가진 프로퍼티의 이름이나 맵에 있는 데이터의 이름으로 동일하게 결정된다.
-            collectionReference.add(deliveryData)
-        }
-        job1.join()
     }
 
     // UserIdx 를 통해 배송지 정보를 가져와 반환한다
-    suspend fun getDeliveryDataByIdx(userIdx: Int): DeliveryData? {
-        // 배송지 정보를 담을 프로퍼티
-        var userDeliveryData: DeliveryData? = null
+    suspend fun getDeliveryDataByIdx(userIdx: Int): List<DeliveryData> {
 
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // Delivery 컬렉션 접근 객체를 가져온다.
-            val collectionReference = db.collection("Delivery")
-            // userIdx 필드가 매개변수로 들어오는 userIdx와 같은 문서들을 가져온다.
-            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
-            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
-            // 회원 번호가 동일한 사용는 없기 때문에 무조건 하나만 나오기 때문이다
-            userDeliveryData = querySnapshot.documents[0].toObject(DeliveryData::class.java)
+        return try {
+            val query = deliveryStore.whereEqualTo("userIdx", userIdx)
+            val querySnapshot = query.get().await()
+            querySnapshot.map { it.toObject(DeliveryData::class.java) }
+
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error getDeliveryDataByIdx : ${e.message}")
+            emptyList()
         }
-        job1.join()
-
-        return userDeliveryData
     }
 
-    // 모든 작가의 정보를 가져온다.
-    suspend fun getDeliveryAll(): MutableList<DeliveryData> {
-        // 사용자 정보를 담을 리스트
-        val deliveryList = mutableListOf<DeliveryData>()
-
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 모든 사용자 정보를 가져온다.
-            val querySnapshot = db.collection("Delivery").get().await()
-            // 가져온 문서의 수 만큼 반복한다.
-            querySnapshot.forEach {
-                // UserModel 객체에 담는다.
-                val deliveryData = it.toObject(DeliveryData::class.java)
-                // 리스트에 담는다.
-                deliveryList.add(deliveryData)
-            }
-        }
-        job1.join()
-
-        return deliveryList
-    }
-
-    // 배송지 정보를 수정하는 메서드
-    suspend fun updateDeliveryData(deliveryData: DeliveryData) {
-        val job1 = CoroutineScope(Dispatchers.IO).launch {
-            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-            val collectionReference = db.collection("Delivery")
-
-            // 컬렉션이 가지고 있는 문서들 중에 수정할 작가 정보를 가져온다.
-            val query =
-                collectionReference.whereEqualTo("deliveryIdx", deliveryData.deliveryIdx).get()
-                    .await()
-
-            // 저장할 데이터를 담을 HashMap을 만들어준다.
-            val map = mutableMapOf<String, Any?>()
-            // 받는 이
-            map["deliveryName"] = deliveryData.deliveryName
-            // 연락처
-            map["deliveryPhone"] = deliveryData.deliveryPhone
-            // 배송지 명(별명)
-            map["deliveryNicName"] = deliveryData.deliveryNickName
-            // 주소
-            map["deliveryAddress"] = deliveryData.deliveryAddress
-            // 배송 메모
-            map["deliveryMemo"] = deliveryData.deliveryMemo
-            // 기본배송지 여부
-            map["basicDelivery"] = deliveryData.basicDelivery
-
-            // 저장한다.
-            // 가져온 문서 중 첫 번째 문서에 접근하여 데이터를 수정한다.
-            query.documents[0].reference.update(map)
-        }
-        job1.join()
-    }
+//        var userDeliveryData: DeliveryData? = null
+//
+//        val job1 = CoroutineScope(Dispatchers.IO).launch {
+//            // Delivery 컬렉션 접근 객체를 가져온다.
+//            val collectionReference = db.collection("Delivery")
+//            // userIdx 필드가 매개변수로 들어오는 userIdx와 같은 문서들을 가져온다.
+//            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+//            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
+//            // 회원 번호가 동일한 사용자는 없기 때문에 무조건 하나만 나오기 때문이다
+//            userDeliveryData = querySnapshot.documents[0].toObject(DeliveryData::class.java)
+//        }
+//        job1.join()
+//        return userDeliveryData
 }
+
+//    // 모든 배송지 정보를 가져온다.
+//    suspend fun getDeliveryAll(): MutableList<DeliveryData> {
+//        // 사용자 정보를 담을 리스트
+//        val deliveryList = mutableListOf<DeliveryData>()
+//
+//        val job1 = CoroutineScope(Dispatchers.IO).launch {
+//            // 모든 사용자 정보를 가져온다.
+//            val querySnapshot = db.collection("Delivery").get().await()
+//            // 가져온 문서의 수 만큼 반복한다.
+//            querySnapshot.forEach {
+//                // UserModel 객체에 담는다.
+//                val deliveryData = it.toObject(DeliveryData::class.java)
+//                // 리스트에 담는다.
+//                deliveryList.add(deliveryData)
+//            }
+//        }
+//        job1.join()
+//
+//        return deliveryList
+//    }
+//
+//    // 배송지 정보를 수정하는 메서드
+//    suspend fun updateDeliveryData(deliveryData: DeliveryData) {
+//        val job1 = CoroutineScope(Dispatchers.IO).launch {
+//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
+//            val collectionReference = db.collection("Delivery")
+//
+//            // 컬렉션이 가지고 있는 문서들 중에 수정할 작가 정보를 가져온다.
+//            val query =
+//                collectionReference.whereEqualTo("deliveryIdx", deliveryData.deliveryIdx).get()
+//                    .await()
+//
+//            // 저장할 데이터를 담을 HashMap을 만들어준다.
+//            val map = mutableMapOf<String, Any?>()
+//            // 받는 이
+//            map["deliveryName"] = deliveryData.deliveryName
+//            // 연락처
+//            map["deliveryPhone"] = deliveryData.deliveryPhone
+//            // 배송지 명(별명)
+//            map["deliveryNicName"] = deliveryData.deliveryNickName
+//            // 주소
+//            map["deliveryAddress"] = deliveryData.deliveryAddress
+//            // 배송 메모
+//            map["deliveryMemo"] = deliveryData.deliveryMemo
+//            // 기본배송지 여부
+//            map["basicDelivery"] = deliveryData.basicDelivery
+//
+//            // 저장한다.
+//            // 가져온 문서 중 첫 번째 문서에 접근하여 데이터를 수정한다.
+//            query.documents[0].reference.update(map)
+//        }
+//        job1.join()
+//    }
+//}

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/DeliveryDataSource.kt
@@ -11,43 +11,6 @@ class DeliveryDataSource {
 
     private val deliveryStore = Firebase.firestore.collection("Delivery")
 
-    //    // 배송지 시퀀스값을 가져온다.
-//    suspend fun getDeliverySequence(): Int {
-//
-//        var deliverySequence = -1
-//
-//        val job1 = CoroutineScope(Dispatchers.IO).launch {
-//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-//            val collectionReference = db.collection("Sequence")
-//            // 사용자 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
-//            val documentReference = collectionReference.document("DeliverySequence")
-//            // 문서내에 있는 데이터를 가져올 수 있는 객체를 가져온다.
-//            val documentSnapShot = documentReference.get().await()
-//
-//            deliverySequence = documentSnapShot.getLong("value")?.toInt() ?: -1
-//        }
-//        job1.join()
-//
-//        return deliverySequence
-//    }
-//
-//    // 배송지 시퀀스 값을 업데이트 한다.
-//    suspend fun updateDeliverySequence(authorSequence: Int) {
-//        val job1 = CoroutineScope(Dispatchers.IO).launch {
-//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-//            val collectionReference = db.collection("Sequence")
-//            // 작가 번호 시퀀스값을 가지고 있는 문서에 접근할 수 있는 객체를 가져온다.
-//            val documentReference = collectionReference.document("DeliverySequence")
-//            // 저장할 데이터를 담을 HashMap을 만들어준다.
-//            val map = mutableMapOf<String, Long>()
-//            // "value"라는 이름의 필드가 있다면 값이 덮어씌워지고 필드가 없다면 필드가 새로 생성된다.
-//            map["value"] = authorSequence.toLong()
-//            // 저장한다.
-//            documentReference.set(map)
-//        }
-//        job1.join()
-//    }
-//
     // 신규 배송지 등록
     suspend fun insertDeliveryData(deliveryData: DeliveryData): Boolean {
         return try {
@@ -90,73 +53,4 @@ class DeliveryDataSource {
             emptyList()
         }
     }
-
-//        var userDeliveryData: DeliveryData? = null
-//
-//        val job1 = CoroutineScope(Dispatchers.IO).launch {
-//            // Delivery 컬렉션 접근 객체를 가져온다.
-//            val collectionReference = db.collection("Delivery")
-//            // userIdx 필드가 매개변수로 들어오는 userIdx와 같은 문서들을 가져온다.
-//            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
-//            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
-//            // 회원 번호가 동일한 사용자는 없기 때문에 무조건 하나만 나오기 때문이다
-//            userDeliveryData = querySnapshot.documents[0].toObject(DeliveryData::class.java)
-//        }
-//        job1.join()
-//        return userDeliveryData
 }
-
-//    // 모든 배송지 정보를 가져온다.
-//    suspend fun getDeliveryAll(): MutableList<DeliveryData> {
-//        // 사용자 정보를 담을 리스트
-//        val deliveryList = mutableListOf<DeliveryData>()
-//
-//        val job1 = CoroutineScope(Dispatchers.IO).launch {
-//            // 모든 사용자 정보를 가져온다.
-//            val querySnapshot = db.collection("Delivery").get().await()
-//            // 가져온 문서의 수 만큼 반복한다.
-//            querySnapshot.forEach {
-//                // UserModel 객체에 담는다.
-//                val deliveryData = it.toObject(DeliveryData::class.java)
-//                // 리스트에 담는다.
-//                deliveryList.add(deliveryData)
-//            }
-//        }
-//        job1.join()
-//
-//        return deliveryList
-//    }
-//
-//    // 배송지 정보를 수정하는 메서드
-//    suspend fun updateDeliveryData(deliveryData: DeliveryData) {
-//        val job1 = CoroutineScope(Dispatchers.IO).launch {
-//            // 컬렉션에 접근할 수 있는 객체를 가져온다.
-//            val collectionReference = db.collection("Delivery")
-//
-//            // 컬렉션이 가지고 있는 문서들 중에 수정할 작가 정보를 가져온다.
-//            val query =
-//                collectionReference.whereEqualTo("deliveryIdx", deliveryData.deliveryIdx).get()
-//                    .await()
-//
-//            // 저장할 데이터를 담을 HashMap을 만들어준다.
-//            val map = mutableMapOf<String, Any?>()
-//            // 받는 이
-//            map["deliveryName"] = deliveryData.deliveryName
-//            // 연락처
-//            map["deliveryPhone"] = deliveryData.deliveryPhone
-//            // 배송지 명(별명)
-//            map["deliveryNicName"] = deliveryData.deliveryNickName
-//            // 주소
-//            map["deliveryAddress"] = deliveryData.deliveryAddress
-//            // 배송 메모
-//            map["deliveryMemo"] = deliveryData.deliveryMemo
-//            // 기본배송지 여부
-//            map["basicDelivery"] = deliveryData.basicDelivery
-//
-//            // 저장한다.
-//            // 가져온 문서 중 첫 번째 문서에 접근하여 데이터를 수정한다.
-//            query.documents[0].reference.update(map)
-//        }
-//        job1.join()
-//    }
-//}

--- a/app/src/main/java/kr/co/lion/unipiece/model/CartData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/CartData.kt
@@ -1,0 +1,11 @@
+package kr.co.lion.unipiece.model
+
+import java.sql.Timestamp
+
+
+data class CartData(
+    var userIdx: Int = 0,
+    var pieceIdx: Int = 0,
+    var cartPieceDate: Timestamp
+
+)

--- a/app/src/main/java/kr/co/lion/unipiece/model/CartData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/CartData.kt
@@ -1,11 +1,13 @@
 package kr.co.lion.unipiece.model
 
-import java.sql.Timestamp
+import com.google.firebase.Timestamp
 
 
 data class CartData(
-    var userIdx: Int = 0,
-    var pieceIdx: Int = 0,
-    var cartPieceDate: Timestamp
+    var userIdx: Int,
+    var pieceIdx: Int,
+    var cartPieceDate: Timestamp,
 
-)
+){
+    constructor() : this(0, 0, Timestamp.now())
+}

--- a/app/src/main/java/kr/co/lion/unipiece/model/DeliveryData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/DeliveryData.kt
@@ -1,15 +1,13 @@
 package kr.co.lion.unipiece.model
 
 data class DeliveryData (
-    var deliveryName : String,
-    var deliveryPhone : String,
-    var deliveryNickName : String,
-    var deliveryAddress : String,
-    var deliveryMemo : String,
-    var basicDelivery : Boolean,
-    var userIdx : Int,
-    var deliveryIdx : Int,
+    var deliveryName : String = "",
+    var deliveryPhone : String = "",
+    var deliveryNickName : String = "",
+    var deliveryAddress : String = "",
+    var deliveryMemo : String = "",
+    var basicDelivery : Boolean = false,
+    var userIdx : Int = -1,
+    var deliveryIdx : Int = -1,
 
-){
-    constructor() : this("", "","","","",true,0,0)
-}
+)

--- a/app/src/main/java/kr/co/lion/unipiece/model/DeliveryData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/DeliveryData.kt
@@ -1,0 +1,15 @@
+package kr.co.lion.unipiece.model
+
+data class DeliveryData (
+    var deliveryName : String,
+    var deliveryPhone : String,
+    var deliveryNickName : String,
+    var deliveryAddress : String,
+    var deliveryMemo : String,
+    var basicDelivery : Boolean,
+    var userIdx : Int,
+    var deliveryIdx : Int,
+
+){
+    constructor() : this("", "","","","",true,0,0)
+}

--- a/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
@@ -1,20 +1,12 @@
 package kr.co.lion.unipiece.repository
 
 import kr.co.lion.unipiece.db.remote.CartDataSource
-import kr.co.lion.unipiece.model.CartData
+import kr.co.lion.unipiece.model.PieceInfoData
 
 class CartRepository {
     private val cartDataSource = CartDataSource()
 
-    // 장바구니 시퀀스값을 가져온다.
-    suspend fun getCartSequence() = cartDataSource.getCartSequence()
-
-    // 장바구니 시퀀스 값을 업데이트 한다.
-    suspend fun updateCartSequence(cartSequence: Int) = cartDataSource.updateCartSequence(cartSequence)
-
     // 작품 번호를 통해 장바구니에 담을 작품 정보를 가져와 반환한다.
-    suspend fun getPieceDataByIdx(pieceIdx:Int) = cartDataSource.getPieceDataByIdx(pieceIdx)
-
-    // 유저 번호를 통해 유저 정보를 가져와 반환한다.
-    suspend fun getUserDataByIdx(userIdx:Int) = cartDataSource.getUserDataByIdx(userIdx)
+    suspend fun getPieceDataByIdx(pieceIdx : Int):MutableList<PieceInfoData> =
+        cartDataSource.getPieceDataByIdx(pieceIdx)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
@@ -1,8 +1,5 @@
 package kr.co.lion.unipiece.repository
 
-import kr.co.lion.unipiece.db.remote.CartDataSource
-import kr.co.lion.unipiece.model.PieceInfoData
-
 class CartRepository {
-    private val cartDataSource = CartDataSource()
+    
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
@@ -5,8 +5,4 @@ import kr.co.lion.unipiece.model.PieceInfoData
 
 class CartRepository {
     private val cartDataSource = CartDataSource()
-
-    // 작품 번호를 통해 장바구니에 담을 작품 정보를 가져와 반환한다.
-    suspend fun getPieceDataByIdx(pieceIdx : Int):MutableList<PieceInfoData> =
-        cartDataSource.getPieceDataByIdx(pieceIdx)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/CartRepository.kt
@@ -1,0 +1,20 @@
+package kr.co.lion.unipiece.repository
+
+import kr.co.lion.unipiece.db.remote.CartDataSource
+import kr.co.lion.unipiece.model.CartData
+
+class CartRepository {
+    private val cartDataSource = CartDataSource()
+
+    // 장바구니 시퀀스값을 가져온다.
+    suspend fun getCartSequence() = cartDataSource.getCartSequence()
+
+    // 장바구니 시퀀스 값을 업데이트 한다.
+    suspend fun updateCartSequence(cartSequence: Int) = cartDataSource.updateCartSequence(cartSequence)
+
+    // 작품 번호를 통해 장바구니에 담을 작품 정보를 가져와 반환한다.
+    suspend fun getPieceDataByIdx(pieceIdx:Int) = cartDataSource.getPieceDataByIdx(pieceIdx)
+
+    // 유저 번호를 통해 유저 정보를 가져와 반환한다.
+    suspend fun getUserDataByIdx(userIdx:Int) = cartDataSource.getUserDataByIdx(userIdx)
+}

--- a/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
@@ -1,0 +1,30 @@
+package kr.co.lion.unipiece.repository
+
+import kr.co.lion.unipiece.db.remote.DeliveryDataSource
+import kr.co.lion.unipiece.model.DeliveryData
+
+class DeliveryRepository {
+    private val deliveryDataSource = DeliveryDataSource()
+
+
+    // 배송지 번호 시퀀스값을 가져온다.
+    suspend fun getDeliverySequence() = deliveryDataSource.getDeliverySequence()
+
+    // 배송지 시퀀스 값을 업데이트 한다.
+    suspend fun updateDeliverySequence(deliverySequence: Int) = deliveryDataSource.updateDeliverySequence(deliverySequence)
+
+    // 배송지 정보를 저장한다.
+    suspend fun insertDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.insertDeliveryData(deliveryData)
+
+    // 유저 번호를 통해 배송지 정보를 가져와 반환한다
+    suspend fun getDeliveryDataByIdx(userIdx:Int) = deliveryDataSource.getDeliveryDataByIdx(userIdx)
+
+    // 모든 배송지의 정보를 가져온다.
+    suspend fun getDeliveryAll():MutableList<DeliveryData> = deliveryDataSource.getDeliveryAll()
+
+    // 배송지 정보를 수정하는 메서드
+    suspend fun updateDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.updateDeliveryData(deliveryData)
+
+
+    
+}

--- a/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
@@ -6,25 +6,10 @@ import kr.co.lion.unipiece.model.DeliveryData
 class DeliveryRepository {
     private val deliveryDataSource = DeliveryDataSource()
 
-
-//    // 배송지 번호 시퀀스값을 가져온다.
-//    suspend fun getDeliverySequence() = deliveryDataSource.getDeliverySequence()
-//
-//    // 배송지 시퀀스 값을 업데이트 한다.
-//    suspend fun updateDeliverySequence(deliverySequence: Int) = deliveryDataSource.updateDeliverySequence(deliverySequence)
-//
-//    // 배송지 정보를 저장한다.
+    // 배송지 정보를 저장한다.
     suspend fun insertDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.insertDeliveryData(deliveryData)
 
     // 유저 번호를 통해 배송지 정보를 가져와 반환한다
     suspend fun getDeliveryDataByIdx(userIdx:Int) = deliveryDataSource.getDeliveryDataByIdx(userIdx)
 
-//    // 모든 배송지의 정보를 가져온다.
-//    suspend fun getDeliveryAll():MutableList<DeliveryData> = deliveryDataSource.getDeliveryAll()
-//
-//    // 배송지 정보를 수정하는 메서드
-//    suspend fun updateDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.updateDeliveryData(deliveryData)
-
-
-    
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/DeliveryRepository.kt
@@ -7,23 +7,23 @@ class DeliveryRepository {
     private val deliveryDataSource = DeliveryDataSource()
 
 
-    // 배송지 번호 시퀀스값을 가져온다.
-    suspend fun getDeliverySequence() = deliveryDataSource.getDeliverySequence()
-
-    // 배송지 시퀀스 값을 업데이트 한다.
-    suspend fun updateDeliverySequence(deliverySequence: Int) = deliveryDataSource.updateDeliverySequence(deliverySequence)
-
-    // 배송지 정보를 저장한다.
+//    // 배송지 번호 시퀀스값을 가져온다.
+//    suspend fun getDeliverySequence() = deliveryDataSource.getDeliverySequence()
+//
+//    // 배송지 시퀀스 값을 업데이트 한다.
+//    suspend fun updateDeliverySequence(deliverySequence: Int) = deliveryDataSource.updateDeliverySequence(deliverySequence)
+//
+//    // 배송지 정보를 저장한다.
     suspend fun insertDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.insertDeliveryData(deliveryData)
 
     // 유저 번호를 통해 배송지 정보를 가져와 반환한다
     suspend fun getDeliveryDataByIdx(userIdx:Int) = deliveryDataSource.getDeliveryDataByIdx(userIdx)
 
-    // 모든 배송지의 정보를 가져온다.
-    suspend fun getDeliveryAll():MutableList<DeliveryData> = deliveryDataSource.getDeliveryAll()
-
-    // 배송지 정보를 수정하는 메서드
-    suspend fun updateDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.updateDeliveryData(deliveryData)
+//    // 모든 배송지의 정보를 가져온다.
+//    suspend fun getDeliveryAll():MutableList<DeliveryData> = deliveryDataSource.getDeliveryAll()
+//
+//    // 배송지 정보를 수정하는 메서드
+//    suspend fun updateDeliveryData(deliveryData: DeliveryData) = deliveryDataSource.updateDeliveryData(deliveryData)
 
 
     

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
@@ -11,6 +11,7 @@ import kr.co.lion.unipiece.databinding.ActivityFollowBinding
 import kr.co.lion.unipiece.databinding.RowFollowBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
+import kr.co.lion.unipiece.ui.mypage.adapter.FollowAdapter
 import kr.co.lion.unipiece.util.CustomDialog
 
 class FollowActivity : AppCompatActivity() {
@@ -50,66 +51,12 @@ class FollowActivity : AppCompatActivity() {
         activityFollowBinding.apply {
             recyclerViewFollowAuthorList.apply {
                 // 어뎁터
-                adapter = MainRecyclerViewAdapter()
+                adapter = FollowAdapter()
                 // 레이아웃 매니저
                 layoutManager = GridLayoutManager(this@FollowActivity,2)
             }
         }
     }
 
-    // 메인 화면의 RecyclerView의 어뎁터
-    inner class MainRecyclerViewAdapter :
-        RecyclerView.Adapter<MainRecyclerViewAdapter.MainViewHolder>() {
-        inner class MainViewHolder(rowFollowBinding: RowFollowBinding) :
-            RecyclerView.ViewHolder(rowFollowBinding.root) {
-            val rowFollowBinding: RowFollowBinding
 
-            init {
-                this.rowFollowBinding = rowFollowBinding
-
-                // 프로필 사진을 클릭 시
-                this.rowFollowBinding.ivProfileImage.setOnClickListener{
-                    val authorInfoIntent = Intent(this@FollowActivity,AuthorInfoActivity::class.java)
-                    startActivity(authorInfoIntent)
-                }
-
-                // 항목별 팔로우 취소 텍스트 버튼 클릭 시
-                this.rowFollowBinding.textButtonFollowCancel.setOnClickListener {
-                    val followCancelDialog = CustomDialog("팔로우 취소", "홍길동 작가 팔로우를 취소하시겠습니까?")
-                    followCancelDialog.show(this@FollowActivity.supportFragmentManager,"FollowCancelCustomDialog")
-                    followCancelDialog.setButtonClickListener(object :CustomDialog.OnButtonClickListener{
-                        override fun okButtonClick() {
-
-                        }
-
-                        override fun noButtonClick() {
-
-                        }
-
-                    })
-                }
-
-                this.rowFollowBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MainViewHolder {
-            val rowFollowBinding = RowFollowBinding.inflate(layoutInflater)
-            val mainViewHolder = MainViewHolder(rowFollowBinding)
-            return mainViewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 10
-        }
-
-        override fun onBindViewHolder(holder: MainViewHolder, position: Int) {
-            holder.rowFollowBinding.textViewFollowListAuthorName.text = "홍길동"
-        }
-
-
-    }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/FollowActivity.kt
@@ -1,18 +1,11 @@
 package kr.co.lion.unipiece.ui.mypage
 
-import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityFollowBinding
-import kr.co.lion.unipiece.databinding.RowFollowBinding
-import kr.co.lion.unipiece.ui.MainActivity
-import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
 import kr.co.lion.unipiece.ui.mypage.adapter.FollowAdapter
-import kr.co.lion.unipiece.util.CustomDialog
 
 class FollowActivity : AppCompatActivity() {
 
@@ -31,7 +24,7 @@ class FollowActivity : AppCompatActivity() {
     }
 
     // 툴바 셋팅
-    fun setToolbar(){
+    fun setToolbar() {
         activityFollowBinding.apply {
             toolbarFollowAuthor.apply {
                 title = "팔로우한 작가"
@@ -47,13 +40,13 @@ class FollowActivity : AppCompatActivity() {
     }
 
     // 메인 화면의 RecyclerView 설정
-    fun setRecyclerViewFollow(){
+    fun setRecyclerViewFollow() {
         activityFollowBinding.apply {
             recyclerViewFollowAuthorList.apply {
                 // 어뎁터
                 adapter = FollowAdapter()
                 // 레이아웃 매니저
-                layoutManager = GridLayoutManager(this@FollowActivity,2)
+                layoutManager = GridLayoutManager(this@FollowActivity, 2)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/FollowAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/FollowAdapter.kt
@@ -1,0 +1,68 @@
+package kr.co.lion.unipiece.ui.mypage.adapter
+
+import android.content.Context
+import android.content.Intent
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowFollowBinding
+import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
+import kr.co.lion.unipiece.util.CustomDialog
+
+// 메인 화면의 RecyclerView의 어뎁터
+class FollowAdapter :
+    RecyclerView.Adapter<FollowViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FollowViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val rowFollowBinding = RowFollowBinding.inflate(inflater, parent, false)
+        val followViewHolder = FollowViewHolder(parent.context, rowFollowBinding)
+        return followViewHolder
+    }
+
+    override fun getItemCount(): Int {
+        return 10
+    }
+
+    override fun onBindViewHolder(holder: FollowViewHolder, position: Int) {
+        holder.rowFollowBinding.textViewFollowListAuthorName.text = "홍길동"
+    }
+
+
+}
+
+class FollowViewHolder(context: Context, rowFollowBinding: RowFollowBinding) :
+    RecyclerView.ViewHolder(rowFollowBinding.root) {
+    val rowFollowBinding: RowFollowBinding
+
+    init {
+        this.rowFollowBinding = rowFollowBinding
+
+        // 프로필 사진을 클릭 시
+        this.rowFollowBinding.ivProfileImage.setOnClickListener {
+            val authorInfoIntent = Intent(context, AuthorInfoActivity::class.java)
+            context.startActivity(authorInfoIntent)
+        }
+
+        // 항목별 팔로우 취소 텍스트 버튼 클릭 시
+        this.rowFollowBinding.textButtonFollowCancel.setOnClickListener {
+            val followCancelDialog = CustomDialog("팔로우 취소", "홍길동 작가 팔로우를 취소하시겠습니까?")
+            //followCancelDialog.show(,"FollowCancelCustomDialog")
+            followCancelDialog.setButtonClickListener(object : CustomDialog.OnButtonClickListener {
+                override fun okButtonClick() {
+
+                }
+
+                override fun noButtonClick() {
+
+                }
+
+            })
+        }
+
+        this.rowFollowBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/CartAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/CartAdapter.kt
@@ -5,7 +5,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.databinding.RowCartBinding
 
-class CartAdapter(private val listener: OnItemCheckStateChangeListener) : RecyclerView.Adapter<CartViewHolder>() {
+class CartAdapter(private val listener: OnItemCheckStateChangeListener) :
+    RecyclerView.Adapter<CartViewHolder>() {
     // 장바구니 화면의 RecyclerView의 어댑터
 
     // 항목의 선택 상태를 저장하는 리스트
@@ -23,7 +24,7 @@ class CartAdapter(private val listener: OnItemCheckStateChangeListener) : Recycl
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CartViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val rowCartBinding = RowCartBinding.inflate(inflater,parent,false)
+        val rowCartBinding = RowCartBinding.inflate(inflater, parent, false)
         val cartViewHolder = CartViewHolder(rowCartBinding)
         return cartViewHolder
     }
@@ -74,6 +75,7 @@ class CartAdapter(private val listener: OnItemCheckStateChangeListener) : Recycl
         return isCheckedList.all { it }
     }
 }
+
 // 리사이클러뷰 뷰홀더
 class CartViewHolder(rowCartBinding: RowCartBinding) :
     RecyclerView.ViewHolder(rowCartBinding.root) {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/DeliveryAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/DeliveryAdapter.kt
@@ -1,6 +1,9 @@
 package kr.co.lion.unipiece.ui.payment.adapter
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.telephony.PhoneNumberUtils
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Toast
@@ -9,41 +12,64 @@ import kr.co.lion.unipiece.databinding.RowDeliveryBinding
 import kr.co.lion.unipiece.model.DeliveryData
 import kr.co.lion.unipiece.ui.payment.delivery.CustomFullDialogListener
 import kr.co.lion.unipiece.ui.payment.delivery.CustomFullDialogMaker
-import kr.co.lion.unipiece.ui.payment.delivery.DeliveryViewModel
 import kr.co.lion.unipiece.util.CustomDialog
+import java.util.Locale
 
 // 배송지 화면의 RecyclerView의 어뎁터
-class DeliveryAdapter : RecyclerView.Adapter<DeliveryViewHolder>() {
+class DeliveryAdapter(
+    var deliveryList: List<DeliveryData>,
+    private val itemClickListener: (Int) -> Unit
+) : RecyclerView.Adapter<DeliveryViewHolder>() {
 
-    private var deliveryList = mutableListOf<DeliveryData>()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DeliveryViewHolder {
-        val inflater = LayoutInflater.from(parent.context)
-        val binding = RowDeliveryBinding.inflate(inflater, parent, false)
-        return DeliveryViewHolder(parent.context, binding)
+    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): DeliveryViewHolder {
+
+        val binding: RowDeliveryBinding =
+            RowDeliveryBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
+        return DeliveryViewHolder(viewGroup.context, binding, itemClickListener)
     }
 
     override fun getItemCount(): Int {
+
         return deliveryList.size
+
     }
 
     override fun onBindViewHolder(holder: DeliveryViewHolder, position: Int) {
-        val item = deliveryList[position] // deliveryList는 예시로, 실제 데이터 리스트 변수명에 맞춰주세요.
-        holder.bind(item)
+        holder.bind(deliveryList[position], itemClickListener)
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(list: List<DeliveryData>) {
+        deliveryList = list
+        notifyDataSetChanged()
+        Log.d("update adapter", list.toString())
+    }
 
 }
 
-class DeliveryViewHolder(private val context: Context,private val binding: RowDeliveryBinding) :
+class DeliveryViewHolder(
+    private val context: Context,
+    val binding: RowDeliveryBinding,
+    private val itemClickListener: (Int) -> Unit
+) :
     RecyclerView.ViewHolder(binding.root) {
-
-    fun bind(data: DeliveryData) { // 예시 타입, 실제 타입으로 대체 필요
-        binding.apply {
+    // 배송지 항목별로 세팅.
+    fun bind(data: DeliveryData, itemClickListener: (Int) -> Unit) {
+        with(binding) {
+            // 받는 이
             textViewDeliveryName.text = data.deliveryName
-            textViewDeliveryNickName.text = data.deliveryNickName
-            textViewDeliveryPhone.text = data.deliveryPhone
+            // 배송지명 (별명)
+            textViewDeliveryNickName.text = "(${data.deliveryNickName})"
+            // 연락처
+            val phoneNumberFormat = PhoneNumberUtils.formatNumber(data.deliveryPhone, Locale.getDefault().country)
+            textViewDeliveryPhone.text = phoneNumberFormat
+            // 주소
             textViewDeliveryAddress.text = data.deliveryAddress
+        }
+        // 클릭 리스너 설정. 클릭하면 deliveryIdx를 전달한다.
+        binding.root.setOnClickListener {
+            itemClickListener.invoke(data.deliveryIdx)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/DeliveryAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/DeliveryAdapter.kt
@@ -1,0 +1,109 @@
+package kr.co.lion.unipiece.ui.payment.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowDeliveryBinding
+import kr.co.lion.unipiece.model.DeliveryData
+import kr.co.lion.unipiece.ui.payment.delivery.CustomFullDialogListener
+import kr.co.lion.unipiece.ui.payment.delivery.CustomFullDialogMaker
+import kr.co.lion.unipiece.ui.payment.delivery.DeliveryViewModel
+import kr.co.lion.unipiece.util.CustomDialog
+
+// 배송지 화면의 RecyclerView의 어뎁터
+class DeliveryAdapter : RecyclerView.Adapter<DeliveryViewHolder>() {
+
+    private var deliveryList = mutableListOf<DeliveryData>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DeliveryViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = RowDeliveryBinding.inflate(inflater, parent, false)
+        return DeliveryViewHolder(parent.context, binding)
+    }
+
+    override fun getItemCount(): Int {
+        return deliveryList.size
+    }
+
+    override fun onBindViewHolder(holder: DeliveryViewHolder, position: Int) {
+        val item = deliveryList[position] // deliveryList는 예시로, 실제 데이터 리스트 변수명에 맞춰주세요.
+        holder.bind(item)
+    }
+
+
+}
+
+class DeliveryViewHolder(private val context: Context,private val binding: RowDeliveryBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(data: DeliveryData) { // 예시 타입, 실제 타입으로 대체 필요
+        binding.apply {
+            textViewDeliveryName.text = data.deliveryName
+            textViewDeliveryNickName.text = data.deliveryNickName
+            textViewDeliveryPhone.text = data.deliveryPhone
+            textViewDeliveryAddress.text = data.deliveryAddress
+        }
+    }
+
+    init {
+        // 항목별 삭제 버튼 클릭 시 다이얼로그
+        this.binding.buttonDeliveryDelete.setOnClickListener {
+            val dialog = CustomDialog("배송지 삭제", "이 배송지를 삭제하시겠습니까?")
+            dialog.setButtonClickListener(object : CustomDialog.OnButtonClickListener {
+                override fun okButtonClick() {
+
+                }
+
+                override fun noButtonClick() {
+
+                }
+
+            })
+            //dialog.show(context, "CustomDialog")
+
+        }
+
+        // 항목별 수정 버튼 클릭 시 풀스크린 다이얼로그
+        this.binding.buttonDeliveryUpdate.setOnClickListener {
+
+            // 커스텀 다이얼로그 (풀스크린)
+            CustomFullDialogMaker.apply {
+                // 다이얼로그 호출
+                getDialog(
+                    context,
+                    "배송지 수정",
+                    "저장하기",
+                    object : CustomFullDialogListener {
+
+                        // 클릭한 이후 동작
+                        // 저장하기 버튼 클릭 후 동작
+                        override fun onClickSaveButton() {
+
+                        }
+
+                        // 뒤로가기 버튼 클릭 후 동작
+                        override fun onClickCancelButton() {
+                            Toast.makeText(context, "뒤로갔다!", Toast.LENGTH_SHORT)
+                                .show()
+
+
+                        }
+                    }
+                )
+            }
+        }
+
+        // 선택 버튼 클릭 시
+        this.binding.buttonDeliverySelect.setOnClickListener {
+
+        }
+
+        // 항목 클릭 시 클릭되는 범위 설정
+        this.binding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/OrderMainAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/OrderMainAdapter.kt
@@ -13,7 +13,8 @@ class OrderMainAdapter :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderMainViewHolder {
 
-        val rowOrderMainBinding = RowOrderMainBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val rowOrderMainBinding =
+            RowOrderMainBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
         return OrderMainViewHolder(rowOrderMainBinding)
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/OrderMainAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/adapter/OrderMainAdapter.kt
@@ -1,0 +1,45 @@
+package kr.co.lion.unipiece.ui.payment.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.unipiece.databinding.RowOrderMainBinding
+
+
+// 주문하기 화면의 RecyclerView의 어뎁터
+class OrderMainAdapter :
+    RecyclerView.Adapter<OrderMainViewHolder>() {
+
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderMainViewHolder {
+
+        val rowOrderMainBinding = RowOrderMainBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return OrderMainViewHolder(rowOrderMainBinding)
+    }
+
+    override fun getItemCount(): Int {
+        return 10
+    }
+
+    override fun onBindViewHolder(holder: OrderMainViewHolder, position: Int) {
+        holder.rowOrderMainBinding.textViewRowOrderMainAuthorName.text = "작가 이름"
+        holder.rowOrderMainBinding.textViewRowOrderMainPieceName.text = "작품 이름"
+        holder.rowOrderMainBinding.textViewRowOrderMainAddDeliveryPrice.text = "추가 배송비 4,000원"
+        holder.rowOrderMainBinding.textViewRowOrderMainPiecePrice.text = "작품 가격"
+
+    }
+}
+
+class OrderMainViewHolder(rowOrderMainBinding: RowOrderMainBinding) :
+    RecyclerView.ViewHolder(rowOrderMainBinding.root) {
+    val rowOrderMainBinding: RowOrderMainBinding
+
+    init {
+        this.rowOrderMainBinding = rowOrderMainBinding
+        this.rowOrderMainBinding.root.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
@@ -32,7 +32,7 @@ class CartActivity : AppCompatActivity() {
     /////////////////////////////// 기능 구현 ///////////////////////////////////////
 
     // 툴바 셋팅
-    fun setToolbar(){
+    fun setToolbar() {
         activityCartBinding.apply {
             toolbarCart.apply {
                 // 타이틀
@@ -50,7 +50,7 @@ class CartActivity : AppCompatActivity() {
     }
 
     // 주문하기 버튼 클릭 시
-    fun clickButtonOrder(){
+    fun clickButtonOrder() {
         activityCartBinding.apply {
             buttonCartOrder.apply {
                 setOnClickListener {
@@ -66,7 +66,7 @@ class CartActivity : AppCompatActivity() {
     ///////////////////////////////////// 리사이클러뷰 ////////////////////////////////////
 
     // 장바구니 화면의 RecyclerView 설정
-    fun setRecyclerViewCart(){
+    fun setRecyclerViewCart() {
         activityCartBinding.apply {
             recyclerViewCartList.apply {
                 // 어댑터 초기화 시 OnItemCheckStateChangeListener 구현을 전달
@@ -85,11 +85,12 @@ class CartActivity : AppCompatActivity() {
 
                 // 마지막 리사이클러뷰 항목의 디바이더 삭제
                 addItemDecoration(
-                    MaterialDividerItemDecoration(this@CartActivity,
+                    MaterialDividerItemDecoration(
+                        this@CartActivity,
                         (layoutManager as LinearLayoutManager).orientation
                     ).apply {
                         isLastItemDecorated = false
-                        setDividerColorResource(this@CartActivity,R.color.lightgray)
+                        setDividerColorResource(this@CartActivity, R.color.lightgray)
                         dividerInsetEnd = 16.dp
                         dividerInsetStart = 16.dp
                     }
@@ -100,7 +101,7 @@ class CartActivity : AppCompatActivity() {
         }
     }
 
-    fun setCheckBoxAll(){
+    fun setCheckBoxAll() {
         // 전체 선택 체크박스 클릭 리스너 설정
         activityCartBinding.checkBoxCartAll.apply {
             setOnClickListener {
@@ -118,7 +119,6 @@ class CartActivity : AppCompatActivity() {
 
 
 }
-
 
 
 // dp값으로 변환하는 확장함수

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.content.res.Resources
 import android.os.Bundle
 import android.util.TypedValue
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.divider.MaterialDividerItemDecoration

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
@@ -1,17 +1,38 @@
 package kr.co.lion.unipiece.ui.payment.cart
 
+import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kr.co.lion.unipiece.model.CartData
+import kr.co.lion.unipiece.model.PieceInfoData
+import kr.co.lion.unipiece.repository.CartRepository
+import kr.co.lion.unipiece.repository.PieceInfoRepository
 import java.sql.Timestamp
 
 class CartViewModel : ViewModel() {
 
-    // 유저 인덱스
-    val userIdx = MutableLiveData<Int>()
-    // 작품 인덱스
-    val pieceIdx = MutableLiveData<Int>()
+    private val cartRepository = CartRepository()
+    private val pieceInfoRepository = PieceInfoRepository()
+
+    // 장바구니 작품 정보
+    private val _cartPieceInfoList = MutableLiveData<PieceInfoData>()
+    val cartPieceInfoList: LiveData<PieceInfoData> = _cartPieceInfoList
+
     // 등록일자
     val cartPieceDate = MutableLiveData<Timestamp>()
+
+    // 작가 정보를 불러오기
+    suspend fun getPieceInfoData(pieceIdx: Int) {
+        val job1 = viewModelScope.launch {
+            // 작품 정보 객체 셋팅
+
+        }
+        job1.join()
+    }
 
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
@@ -23,9 +23,6 @@ class CartViewModel : ViewModel() {
     private val _cartPieceInfoList = MutableLiveData<PieceInfoData>()
     val cartPieceInfoList: LiveData<PieceInfoData> = _cartPieceInfoList
 
-    // 등록일자
-    val cartPieceDate = MutableLiveData<Timestamp>()
-
     // 작가 정보를 불러오기
     suspend fun getPieceInfoData(pieceIdx: Int) {
         val job1 = viewModelScope.launch {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/cart/CartViewModel.kt
@@ -1,0 +1,17 @@
+package kr.co.lion.unipiece.ui.payment.cart
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import kr.co.lion.unipiece.model.CartData
+import java.sql.Timestamp
+
+class CartViewModel : ViewModel() {
+
+    // 유저 인덱스
+    val userIdx = MutableLiveData<Int>()
+    // 작품 인덱스
+    val pieceIdx = MutableLiveData<Int>()
+    // 등록일자
+    val cartPieceDate = MutableLiveData<Timestamp>()
+
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/CustomFullDialogListener.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/CustomFullDialogListener.kt
@@ -1,6 +1,6 @@
 package kr.co.lion.unipiece.ui.payment.delivery
-
 interface CustomFullDialogListener {
-    fun onClickSaveButton()
+    fun onClickSaveButton(
+    )
     fun onClickCancelButton()
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/CustomFullDialogMaker.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/CustomFullDialogMaker.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.content.Context
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.DialogDeliveryAddBinding
+import kr.co.lion.unipiece.model.DeliveryData
 
 object CustomFullDialogMaker {
 
@@ -12,7 +13,7 @@ object CustomFullDialogMaker {
         context: Context,
         title: String,
         saveButtonText: String,
-        target: CustomFullDialogListener
+        target: CustomFullDialogListener,
     ) {
         val dialog = Dialog(context, R.style.Theme_UniPiece)
         val dialogBinding = DialogDeliveryAddBinding.inflate(dialog.layoutInflater)
@@ -34,7 +35,6 @@ object CustomFullDialogMaker {
                 // // 뒤로가기 내비게이션버튼 클릭 시 동작
                 this.setNavigationOnClickListener {
                     target.onClickCancelButton()
-
                     // 다이얼로그 종료
                     dialog.dismiss()
                 }
@@ -50,7 +50,13 @@ object CustomFullDialogMaker {
 
                 // 저장버튼 클릭 시 동작
                 this.setOnClickListener {
+
+
+
+
                     target.onClickSaveButton()
+
+
 
                     // 다이얼로그 종료
                     dialog.dismiss()

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryActivity.kt
@@ -1,10 +1,9 @@
 package kr.co.lion.unipiece.ui.payment.delivery
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.SystemClock
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import com.google.android.material.transition.MaterialSharedAxis
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityDeliveryBinding
 import kr.co.lion.unipiece.util.DeliveryFragmentName
@@ -14,8 +13,7 @@ class DeliveryActivity : AppCompatActivity() {
     lateinit var activityDeliveryBinding: ActivityDeliveryBinding
 
     var oldFragment: Fragment? = null
-    var newFragment:Fragment? = null
-
+    var newFragment: Fragment? = null
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,28 +26,29 @@ class DeliveryActivity : AppCompatActivity() {
 
     }
 
-    fun replaceFragment(name:DeliveryFragmentName, addToBackStack:Boolean){
+    fun replaceFragment(name: DeliveryFragmentName, addToBackStack: Boolean) {
         SystemClock.sleep(200)
         // Fragment를 교체할 수 있는 객체를 추출한다.
         val fragmentTransaction = supportFragmentManager.beginTransaction()
         // oldFragment에 newFragment가 가지고 있는 Fragment 객체를 담아준다.
-        if(newFragment != null){
+        if (newFragment != null) {
             oldFragment = newFragment
         }
         // 이름으로 분기한다.
-        when(name){
+        when (name) {
             DeliveryFragmentName.DELIVERY_MANAGER_FRAGMENT -> {
                 newFragment = DeliveryManagerFragment()
             }
+
             DeliveryFragmentName.DELIVERY_ADD_FRAGMENT -> {
                 newFragment = DeliveryAddFragment()
             }
 
         }
-        if(newFragment != null){
+        if (newFragment != null) {
             fragmentTransaction.replace(R.id.containerDelivery, newFragment!!)
             // addToBackStack 변수의 값이 true면 새롭게 보여질 Fragment를 BackStack에 포함시켜 준다.
-            if(addToBackStack == true){
+            if (addToBackStack == true) {
                 // BackStack 포함 시킬때 이름을 지정해주면 원하는 Fragment를 BackStack에서 제거할 수 있다.
                 fragmentTransaction.addToBackStack(name.str)
             }
@@ -57,8 +56,9 @@ class DeliveryActivity : AppCompatActivity() {
             fragmentTransaction.commit()
         }
     }
+
     // BackStack에서 Fragment를 제거한다.
-    fun removeFragment(name: DeliveryManagerFragment){
+    fun removeFragment(name: DeliveryManagerFragment) {
         SystemClock.sleep(200)
         // 지정한 이름으로 있는 Fragment를 BackStack에서 제거한다.
         // supportFragmentManager.popBackStack(name.str, FragmentManager.POP_BACK_STACK_INCLUSIVE)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryAddFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryAddFragment.kt
@@ -10,6 +10,8 @@ class DeliveryAddFragment : DialogFragment() {
 
     lateinit var dialogDeliveryAddBinding: DialogDeliveryAddBinding
 
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         dialogDeliveryAddBinding = DialogDeliveryAddBinding.inflate(layoutInflater)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryAddFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryAddFragment.kt
@@ -2,7 +2,6 @@ package kr.co.lion.unipiece.ui.payment.delivery
 
 
 import android.os.Bundle
-
 import androidx.fragment.app.DialogFragment
 import kr.co.lion.unipiece.databinding.DialogDeliveryAddBinding
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryManagerFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryManagerFragment.kt
@@ -1,18 +1,16 @@
 package kr.co.lion.unipiece.ui.payment.delivery
 
-import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentDeliveryManagerBinding
 import kr.co.lion.unipiece.databinding.RowDeliveryBinding
-import kr.co.lion.unipiece.ui.payment.order.OrderActivity
 import kr.co.lion.unipiece.util.CustomDialog
 
 class DeliveryManagerFragment : Fragment() {
@@ -37,11 +35,10 @@ class DeliveryManagerFragment : Fragment() {
     }
 
 
-
     ///////////////////////////////////////////기능 구현/////////////////////////////////////////////
 
     // 툴바 셋팅
-    fun setToolbar(){
+    fun setToolbar() {
         fragmentDeliveryManagerBinding.apply {
             toolbarDeliveryManager.apply {
 
@@ -125,9 +122,9 @@ class DeliveryManagerFragment : Fragment() {
                 this.rowDeliveryBinding = rowDeliveryBinding
 
                 // 항목별 삭제 버튼 클릭 시 다이얼로그
-                this.rowDeliveryBinding.buttonDeliveryDelete.setOnClickListener{
+                this.rowDeliveryBinding.buttonDeliveryDelete.setOnClickListener {
                     val dialog = CustomDialog("배송지 삭제", "이 배송지를 삭제하시겠습니까?")
-                    dialog.setButtonClickListener(object :CustomDialog.OnButtonClickListener{
+                    dialog.setButtonClickListener(object : CustomDialog.OnButtonClickListener {
                         override fun okButtonClick() {
 
                         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
@@ -49,15 +49,5 @@ class DeliveryViewModel : ViewModel() {
         }
 
     }
-
-//    // 신규 배송지 등록하기
-//    suspend fun insertDeliveryData(deliveryData: DeliveryData){
-//        val job1 = viewModelScope.launch{
-//            deliveryRepository.insertDeliveryData(deliveryData)
-//            // 등록 후, 필요하다면 UI 업데이트를 위한 추가 작업 수행
-//            // 예: 새로운 배송지 정보를 _deliveryData에 설정
-//            _deliveryData.value = deliveryData
-//        }
-//        job1.join()
-//    }
+    
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
@@ -1,0 +1,36 @@
+package kr.co.lion.unipiece.ui.payment.delivery
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.model.DeliveryData
+import kr.co.lion.unipiece.repository.DeliveryRepository
+
+class DeliveryViewModel : ViewModel() {
+    // 배송지 정보
+    private val _deliveryData = MutableLiveData<DeliveryData>()
+    val deliveryData: LiveData<DeliveryData> = _deliveryData
+
+    private val deliveryRepository = DeliveryRepository()
+
+    // 배송지 정보 불러오기
+    suspend fun getDeliveryData(userIdx: Int){
+        val job1 = viewModelScope.launch{
+            _deliveryData.value = deliveryRepository.getDeliveryDataByIdx(userIdx)
+        }
+        job1.join()
+    }
+
+    // 신규 배송지 등록하기
+    suspend fun insertDeliveryData(deliveryData: DeliveryData){
+        val job1 = viewModelScope.launch{
+            deliveryRepository.insertDeliveryData(deliveryData)
+            // 등록 후, 필요하다면 UI 업데이트를 위한 추가 작업 수행
+            // 예: 새로운 배송지 정보를 _deliveryData에 설정
+            _deliveryData.value = deliveryData
+        }
+        job1.join()
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/delivery/DeliveryViewModel.kt
@@ -1,36 +1,63 @@
 package kr.co.lion.unipiece.ui.payment.delivery
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.model.DeliveryData
+import kr.co.lion.unipiece.model.PieceAddInfoData
 import kr.co.lion.unipiece.repository.DeliveryRepository
 
 class DeliveryViewModel : ViewModel() {
-    // 배송지 정보
-    private val _deliveryData = MutableLiveData<DeliveryData>()
-    val deliveryData: LiveData<DeliveryData> = _deliveryData
 
     private val deliveryRepository = DeliveryRepository()
 
-    // 배송지 정보 불러오기
-    suspend fun getDeliveryData(userIdx: Int){
-        val job1 = viewModelScope.launch{
-            _deliveryData.value = deliveryRepository.getDeliveryDataByIdx(userIdx)
+    // 배송지 정보 가져오기
+    private val _deliveryDataList = MutableLiveData<List<DeliveryData>>()
+    val deliveryDataList: LiveData<List<DeliveryData>> = _deliveryDataList
+
+    // 신규 배송지 등록하기
+    private val _insertDeliveryDataResult = MutableLiveData<Boolean>()
+    val insertDeliveryDataResult: LiveData<Boolean> = _insertDeliveryDataResult
+
+    val userIdx = UniPieceApplication.prefs.getUserIdx("userIdx",0)
+
+    init{
+        viewModelScope.launch {
+            getDeliveryDataByIdx(userIdx)
         }
-        job1.join()
+    }
+
+    // 배송지 정보 불러오기
+    suspend fun getDeliveryDataByIdx(userIdx: Int) {
+
+        val response = deliveryRepository.getDeliveryDataByIdx(userIdx)
+        Log.d("test1234","${response}")
+        _deliveryDataList.value = response
     }
 
     // 신규 배송지 등록하기
-    suspend fun insertDeliveryData(deliveryData: DeliveryData){
-        val job1 = viewModelScope.launch{
+    suspend fun insertDeliveryData(deliveryData: DeliveryData) {
+        try {
             deliveryRepository.insertDeliveryData(deliveryData)
-            // 등록 후, 필요하다면 UI 업데이트를 위한 추가 작업 수행
-            // 예: 새로운 배송지 정보를 _deliveryData에 설정
-            _deliveryData.value = deliveryData
+            _insertDeliveryDataResult.value = true
+        }catch (e:Exception){
+            _insertDeliveryDataResult.value = false
         }
-        job1.join()
+
     }
+
+//    // 신규 배송지 등록하기
+//    suspend fun insertDeliveryData(deliveryData: DeliveryData){
+//        val job1 = viewModelScope.launch{
+//            deliveryRepository.insertDeliveryData(deliveryData)
+//            // 등록 후, 필요하다면 UI 업데이트를 위한 추가 작업 수행
+//            // 예: 새로운 배송지 정보를 _deliveryData에 설정
+//            _deliveryData.value = deliveryData
+//        }
+//        job1.join()
+//    }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderActivity.kt
@@ -1,11 +1,10 @@
 package kr.co.lion.unipiece.ui.payment.order
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.SystemClock
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import com.google.android.material.transition.MaterialSharedAxis
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.ActivityOrderBinding
 import kr.co.lion.unipiece.util.OrderFragmentName
@@ -26,16 +25,16 @@ class OrderActivity : AppCompatActivity() {
     }
 
     // 지정한 Fragment를 보여주는 메서드
-    fun replaceFragment(name:OrderFragmentName, addToBackStack:Boolean){
+    fun replaceFragment(name: OrderFragmentName, addToBackStack: Boolean) {
         SystemClock.sleep(200)
         // Fragment를 교체할 수 있는 객체를 추출한다.
         val fragmentTransaction = supportFragmentManager.beginTransaction()
         // oldFragment에 newFragment가 가지고 있는 Fragment 객체를 담아준다.
-        if(newFragment != null){
+        if (newFragment != null) {
             oldFragment = newFragment
         }
         // 이름으로 분기한다.
-        when(name){
+        when (name) {
             OrderFragmentName.ORDER_MAIN_FRAGMENT -> {
                 newFragment = OrderMainFragment()
             }
@@ -44,10 +43,10 @@ class OrderActivity : AppCompatActivity() {
                 newFragment = OrderSuccessFragment()
             }
         }
-        if(newFragment != null){
+        if (newFragment != null) {
             fragmentTransaction.replace(R.id.containerOrder, newFragment!!)
             // addToBackStack 변수의 값이 true면 새롭게 보여질 Fragment를 BackStack에 포함시켜 준다.
-            if(addToBackStack == true){
+            if (addToBackStack == true) {
                 // BackStack 포함 시킬때 이름을 지정해주면 원하는 Fragment를 BackStack에서 제거할 수 있다.
                 fragmentTransaction.addToBackStack(name.str)
             }
@@ -55,8 +54,9 @@ class OrderActivity : AppCompatActivity() {
             fragmentTransaction.commit()
         }
     }
+
     // BackStack에서 Fragment를 제거한다.
-    fun removeFragment(name: OrderFragmentName){
+    fun removeFragment(name: OrderFragmentName) {
         SystemClock.sleep(200)
         // 지정한 이름으로 있는 Fragment를 BackStack에서 제거한다.
         supportFragmentManager.popBackStack(name.str, FragmentManager.POP_BACK_STACK_INCLUSIVE)

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -3,25 +3,18 @@ package kr.co.lion.unipiece.ui.payment.order
 import android.content.Intent
 import android.content.res.Resources
 import android.os.Bundle
-import android.util.Log
 import android.util.TypedValue
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.databinding.FragmentOrderMainBinding
-import kr.co.lion.unipiece.databinding.RowCartBinding
-import kr.co.lion.unipiece.databinding.RowOrderMainBinding
-import kr.co.lion.unipiece.ui.payment.cart.CartActivity
+import kr.co.lion.unipiece.ui.payment.adapter.OrderMainAdapter
 import kr.co.lion.unipiece.ui.payment.delivery.DeliveryActivity
 
-import kr.co.lion.unipiece.util.OrderFragmentName
-
-import kr.co.lion.unipiece.ui.payment.order.OrderActivity
 
 
 
@@ -37,6 +30,7 @@ class OrderMainFragment : Fragment() {
         setRecyclerViewOrderMain()
 
         clickButtonPayment()
+        setOrderDetail()
 
         return fragmentOrderMainBinding.root
     }
@@ -84,13 +78,27 @@ class OrderMainFragment : Fragment() {
         }
     }
 
+    // 주문상세 설정
+    fun setOrderDetail(){
+        with(fragmentOrderMainBinding){
+            with(containerOrderDetail){
+                // 추가 배송비 합계
+                textViewOrderMainAddDeliveryPrice.text = "${"추가 배송비 합계"} 원"
+                // 작품 가격 합계
+                textViewOrderMainPiecePrice.text = "${"작품 가격 합계"} 원"
+            }
+        }
+
+    }
+
+
     ///////////////////////////////// 리사이클러뷰 ///////////////////////////////////////
     // 주문하기 화면의 RecyclerView 설정
     fun setRecyclerViewOrderMain(){
         fragmentOrderMainBinding.apply {
             recyclerViewOrderList.apply {
                 // 어뎁터
-                adapter = OrderMainRecyclerViewAdapter()
+                adapter = OrderMainAdapter()
                 // 레이아웃 매니저
                 layoutManager = LinearLayoutManager(requireActivity())
 
@@ -100,44 +108,13 @@ class OrderMainFragment : Fragment() {
                         (layoutManager as LinearLayoutManager).orientation
                     ).apply {
                         isLastItemDecorated = false
-                        setDividerColorResource(requireActivity(),R.color.lightgray)
+                        setDividerColorResource(requireActivity(), R.color.lightgray)
                         dividerInsetEnd = 16.dp
                         dividerInsetStart = 16.dp
                     }
 
                 )
             }
-        }
-    }
-
-    // 주문하기 화면의 RecyclerView의 어뎁터
-    inner class OrderMainRecyclerViewAdapter :
-        RecyclerView.Adapter<OrderMainRecyclerViewAdapter.OrderMainViewHolder>() {
-        inner class OrderMainViewHolder(rowOrderMainBinding: RowOrderMainBinding) :
-            RecyclerView.ViewHolder(rowOrderMainBinding.root) {
-            val rowOrderMainBinding: RowOrderMainBinding
-
-            init {
-                this.rowOrderMainBinding = rowOrderMainBinding
-                this.rowOrderMainBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderMainViewHolder {
-            val rowOrderMainBinding = RowOrderMainBinding.inflate(layoutInflater)
-            val orderMainViewHolder = OrderMainViewHolder(rowOrderMainBinding)
-            return orderMainViewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 10
-        }
-
-        override fun onBindViewHolder(holder: OrderMainViewHolder, position: Int) {
-            holder.rowOrderMainBinding.textViewRowOrderMain.text = "테스트라고"
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderMainFragment.kt
@@ -4,10 +4,10 @@ import android.content.Intent
 import android.content.res.Resources
 import android.os.Bundle
 import android.util.TypedValue
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import kr.co.lion.unipiece.R
@@ -16,13 +16,15 @@ import kr.co.lion.unipiece.ui.payment.adapter.OrderMainAdapter
 import kr.co.lion.unipiece.ui.payment.delivery.DeliveryActivity
 
 
-
-
 class OrderMainFragment : Fragment() {
 
     lateinit var fragmentOrderMainBinding: FragmentOrderMainBinding
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         // Inflate the layout for this fragment
         fragmentOrderMainBinding = FragmentOrderMainBinding.inflate(layoutInflater)
         setToolbar()
@@ -36,7 +38,7 @@ class OrderMainFragment : Fragment() {
     }
 
     // 툴바 설정
-    fun setToolbar(){
+    fun setToolbar() {
         fragmentOrderMainBinding.apply {
             toolbarOrderMain.apply {
                 // 타이틀
@@ -54,7 +56,7 @@ class OrderMainFragment : Fragment() {
     }
 
     // 배송지 변경 버튼 클릭
-    fun clickButtonDeliveryChange(){
+    fun clickButtonDeliveryChange() {
         fragmentOrderMainBinding.apply {
             buttonOrderDeliveryChange.setOnClickListener {
                 // DeliveryActivity를 실행한다.
@@ -65,7 +67,7 @@ class OrderMainFragment : Fragment() {
     }
 
     // 결제하기 버튼 클릭
-    fun clickButtonPayment(){
+    fun clickButtonPayment() {
         fragmentOrderMainBinding.apply {
             buttonOrderPaymentSubmit.apply {
                 setOnClickListener {
@@ -79,9 +81,9 @@ class OrderMainFragment : Fragment() {
     }
 
     // 주문상세 설정
-    fun setOrderDetail(){
-        with(fragmentOrderMainBinding){
-            with(containerOrderDetail){
+    fun setOrderDetail() {
+        with(fragmentOrderMainBinding) {
+            with(containerOrderDetail) {
                 // 추가 배송비 합계
                 textViewOrderMainAddDeliveryPrice.text = "${"추가 배송비 합계"} 원"
                 // 작품 가격 합계
@@ -94,7 +96,7 @@ class OrderMainFragment : Fragment() {
 
     ///////////////////////////////// 리사이클러뷰 ///////////////////////////////////////
     // 주문하기 화면의 RecyclerView 설정
-    fun setRecyclerViewOrderMain(){
+    fun setRecyclerViewOrderMain() {
         fragmentOrderMainBinding.apply {
             recyclerViewOrderList.apply {
                 // 어뎁터
@@ -104,7 +106,8 @@ class OrderMainFragment : Fragment() {
 
                 // 마지막 리사이클러뷰 항목의 디바이더 삭제
                 addItemDecoration(
-                    MaterialDividerItemDecoration(requireActivity(),
+                    MaterialDividerItemDecoration(
+                        requireActivity(),
                         (layoutManager as LinearLayoutManager).orientation
                     ).apply {
                         isLastItemDecorated = false

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderSuccessFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderSuccessFragment.kt
@@ -3,24 +3,24 @@ package kr.co.lion.unipiece.ui.payment.order
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedDispatcher
-import androidx.activity.addCallback
-import kr.co.lion.unipiece.R
+import androidx.fragment.app.Fragment
 import kr.co.lion.unipiece.databinding.FragmentOrderSuccessBinding
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.mygallery.PurchasedPieceDetailActivity
-import kr.co.lion.unipiece.util.OrderFragmentName
 
 class OrderSuccessFragment : Fragment() {
 
     lateinit var fragmentOrderSuccessBinding: FragmentOrderSuccessBinding
 
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         // Inflate the layout for this fragment
 
         fragmentOrderSuccessBinding = FragmentOrderSuccessBinding.inflate(layoutInflater)
@@ -32,12 +32,13 @@ class OrderSuccessFragment : Fragment() {
     }
 
     // 결제 내역 보기 버튼 클릭 시
-    fun clickButtonPaymentDetail(){
+    fun clickButtonPaymentDetail() {
 
         fragmentOrderSuccessBinding.apply {
             buttonPaymentDetailSee.apply {
                 setOnClickListener {
-                    val purchasedIntent = Intent(requireActivity(),PurchasedPieceDetailActivity::class.java)
+                    val purchasedIntent =
+                        Intent(requireActivity(), PurchasedPieceDetailActivity::class.java)
                     startActivity(purchasedIntent)
                 }
             }
@@ -45,11 +46,11 @@ class OrderSuccessFragment : Fragment() {
     }
 
     // 계속 쇼핑하기 버튼 클릭 시
-    fun clickButtonContinueShopping(){
+    fun clickButtonContinueShopping() {
         fragmentOrderSuccessBinding.apply {
             buttonContinueShopping.apply {
                 setOnClickListener {
-                    val buyIntent = Intent(requireActivity(),MainActivity::class.java)
+                    val buyIntent = Intent(requireActivity(), MainActivity::class.java)
                     val mainActivity = startActivity(buyIntent)
 
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderSuccessFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/payment/order/OrderSuccessFragment.kt
@@ -50,7 +50,8 @@ class OrderSuccessFragment : Fragment() {
             buttonContinueShopping.apply {
                 setOnClickListener {
                     val buyIntent = Intent(requireActivity(),MainActivity::class.java)
-                    startActivity(buyIntent)
+                    val mainActivity = startActivity(buyIntent)
+
 
                 }
             }

--- a/app/src/main/res/layout/dialog_delivery_add.xml
+++ b/app/src/main/res/layout/dialog_delivery_add.xml
@@ -217,7 +217,7 @@
             app:hintTextColor="@color/second">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/buttonDeliveryAddAdress"
+                android:id="@+id/textFieldDeliveryAddAdress"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:background="@drawable/textfield_radius"
@@ -235,10 +235,11 @@
             app:hintTextColor="@color/second">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/textFieldDeliveryAddAddressDetail"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:background="@drawable/textfield_radius"
-                android:paddingLeft="15dp"/>
+                android:paddingLeft="15dp" />
         </com.google.android.material.textfield.TextInputLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_order_main.xml
+++ b/app/src/main/res/layout/fragment_order_main.xml
@@ -224,6 +224,7 @@
                         app:cardElevation="2dp"
                         app:cardCornerRadius="10dp">
                         <LinearLayout
+                            android:id="@+id/containerOrderDetail"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:orientation="vertical"

--- a/app/src/main/res/layout/row_cart.xml
+++ b/app/src/main/res/layout/row_cart.xml
@@ -1,63 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- 뷰모델 객체 정의 -->
+    <data>
+        <variable
+            name="cartViewModel"
+            type="kr.co.lion.unipiece.ui.payment.cart.CartViewModel" />
+    </data>
+    <!-- 뷰모델 객체 정의 끝 -->
 
     <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
-        android:orientation="horizontal">
+        android:layout_height="match_parent">
 
-        <CheckBox
-            android:id="@+id/checkBoxCartRow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal|center_vertical" />
-
-        <ImageView
-            android:id="@+id/imageView"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            app:srcCompat="@drawable/mygallery_icon" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="10dp">
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp"
+            android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/textViewRowCart"
+
+            <CheckBox
+                android:id="@+id/checkBoxCartRow"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="작품 제목"
-                android:textSize="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:layout_gravity="center_horizontal|center_vertical" />
 
-            <TextView
-                android:id="@+id/textViewRowCartPiecePrice"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="작품 가격"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                app:srcCompat="@drawable/mygallery_icon" />
 
-            <TextView
-                android:id="@+id/textViewRowCartAuthorName"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="작가 이름"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textViewRowCart" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="10dp">
+
+                <TextView
+                    android:id="@+id/textViewRowCart"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{cartViewModel.userIdx.toString()}"
+                    android:textSize="20dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/textViewRowCartPiecePrice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="작품 가격"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
+                <TextView
+                    android:id="@+id/textViewRowCartAuthorName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="작가 이름"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textViewRowCart" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </LinearLayout>
+
 
     </LinearLayout>
-
-
-</LinearLayout>
+</layout>

--- a/app/src/main/res/layout/row_cart.xml
+++ b/app/src/main/res/layout/row_cart.xml
@@ -25,11 +25,37 @@
             android:layout_height="100dp"
             app:srcCompat="@drawable/mygallery_icon" />
 
-        <TextView
-            android:id="@+id/textViewRowCart"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:text="테스트다 이자식아" />
+            android:padding="10dp">
+
+            <TextView
+                android:id="@+id/textViewRowCart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="작품 제목"
+                android:textSize="20dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewRowCartPiecePrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="작품 가격"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewRowCartAuthorName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="작가 이름"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textViewRowCart" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/row_cart.xml
+++ b/app/src/main/res/layout/row_cart.xml
@@ -10,7 +10,6 @@
             type="kr.co.lion.unipiece.ui.payment.cart.CartViewModel" />
     </data>
     <!-- 뷰모델 객체 정의 끝 -->
-
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
@@ -45,7 +44,8 @@
                     android:id="@+id/textViewRowCart"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{cartViewModel.userIdx.toString()}"
+                    android:text=""
+
                     android:textSize="20dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/row_delivery.xml
+++ b/app/src/main/res/layout/row_delivery.xml
@@ -1,122 +1,131 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.cardview.widget.CardView
+    <data>
+        <variable
+            name="deliveryViewModel"
+            type="kr.co.lion.unipiece.ui.payment.delivery.DeliveryViewModel" />
+    </data>
+
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:layout_marginBottom="5dp"
-        app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="10dp"
-        app:cardPreventCornerOverlap="true">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <LinearLayout
+        <androidx.cardview.widget.CardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:padding="10dp">
+            android:layout_marginTop="5dp"
+            android:layout_marginBottom="5dp"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="10dp"
+            app:cardPreventCornerOverlap="true">
 
             <LinearLayout
-                android:layout_width="300dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="horizontal"
+                android:padding="10dp">
 
                 <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <TextView
-                        android:id="@+id/textViewDeliveryName"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="left"
-                        android:text="홍길동" />
-
-                    <TextView
-                        android:id="@+id/textViewDeliveryAdressName"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="(공중화장실)"
-                        android:textAlignment="textStart" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
+                    android:layout_width="300dp"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <TextView
-                        android:id="@+id/textViewDeliveryPhone"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="20dp"
-                        android:text="01015447979" />
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:id="@+id/textViewDeliveryAddress"
+                        <TextView
+                            android:id="@+id/textViewDeliveryName"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="@{deliveryViewModel.deliveryData.deliveryName}" />
+
+                        <TextView
+                            android:id="@+id/textViewDeliveryNickName"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@{deliveryViewModel.deliveryData.deliveryNickName}"
+                            android:textAlignment="textStart" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="서울" />
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/textViewDeliveryPhone"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="20dp"
+                            android:text="@{deliveryViewModel.deliveryData.deliveryPhone}" />
+
+                        <TextView
+                            android:id="@+id/textViewDeliveryAddress"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@{deliveryViewModel.deliveryData.deliveryAddress}" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+
+                        <Button
+                            android:id="@+id/buttonDeliveryUpdate"
+                            android:layout_width="40dp"
+                            android:layout_height="30dp"
+                            android:background="@drawable/button_radius"
+                            android:padding="0dp"
+                            android:paddingLeft="0dp"
+                            android:paddingRight="0dp"
+                            android:text="수정"
+                            android:textColor="@color/white" />
+
+                        <Button
+                            android:id="@+id/buttonDeliveryDelete"
+                            android:layout_width="40dp"
+                            android:layout_height="30dp"
+                            android:layout_marginLeft="10dp"
+                            android:background="@drawable/button_radius"
+                            android:padding="0dp"
+                            android:paddingLeft="0dp"
+                            android:paddingRight="0dp"
+                            android:text="삭제"
+                            android:textColor="@color/white" />
+                    </LinearLayout>
 
                 </LinearLayout>
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_height="match_parent">
 
                     <Button
-                        android:id="@+id/buttonDeliveryUpdate"
+                        android:id="@+id/buttonDeliverySelect"
                         android:layout_width="40dp"
                         android:layout_height="30dp"
                         android:background="@drawable/button_radius"
                         android:padding="0dp"
-                        android:paddingLeft="0dp"
-                        android:paddingRight="0dp"
-                        android:text="수정"
-                        android:textColor="@color/white" />
-
-                    <Button
-                        android:id="@+id/buttonDeliveryDelete"
-                        android:layout_width="40dp"
-                        android:layout_height="30dp"
-                        android:layout_marginLeft="10dp"
-                        android:background="@drawable/button_radius"
-                        android:padding="0dp"
-                        android:paddingLeft="0dp"
-                        android:paddingRight="0dp"
-                        android:text="삭제"
-                        android:textColor="@color/white" />
-                </LinearLayout>
-
+                        android:text="선택"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
             </LinearLayout>
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+        </androidx.cardview.widget.CardView>
 
-                <Button
-                    android:id="@+id/buttonDeliverySelect"
-                    android:layout_width="40dp"
-                    android:layout_height="30dp"
-                    android:background="@drawable/button_radius"
-                    android:padding="0dp"
-                    android:text="선택"
-                    android:textColor="@color/white"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </LinearLayout>
-
-    </androidx.cardview.widget.CardView>
-
-</LinearLayout>
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/row_delivery.xml
+++ b/app/src/main/res/layout/row_delivery.xml
@@ -1,131 +1,121 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <data>
-        <variable
-            name="deliveryViewModel"
-            type="kr.co.lion.unipiece.ui.payment.delivery.DeliveryViewModel" />
-    </data>
-
-    <LinearLayout
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="5dp"
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="10dp"
+        app:cardPreventCornerOverlap="true">
 
-        <androidx.cardview.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:layout_marginBottom="5dp"
-            app:cardBackgroundColor="@color/white"
-            app:cardCornerRadius="10dp"
-            app:cardPreventCornerOverlap="true">
+            android:orientation="horizontal"
+            android:padding="10dp">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="300dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:padding="10dp">
+                android:orientation="vertical">
 
                 <LinearLayout
-                    android:layout_width="300dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="horizontal">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                    <TextView
+                        android:id="@+id/textViewDeliveryName"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                        android:gravity="left" />
 
-                        <TextView
-                            android:id="@+id/textViewDeliveryName"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="left"
-                            android:text="@{deliveryViewModel.deliveryData.deliveryName}" />
-
-                        <TextView
-                            android:id="@+id/textViewDeliveryNickName"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@{deliveryViewModel.deliveryData.deliveryNickName}"
-                            android:textAlignment="textStart" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                    <TextView
+                        android:id="@+id/textViewDeliveryNickName"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/textViewDeliveryPhone"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="20dp"
-                            android:text="@{deliveryViewModel.deliveryData.deliveryPhone}" />
-
-                        <TextView
-                            android:id="@+id/textViewDeliveryAddress"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@{deliveryViewModel.deliveryData.deliveryAddress}" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-
-                        <Button
-                            android:id="@+id/buttonDeliveryUpdate"
-                            android:layout_width="40dp"
-                            android:layout_height="30dp"
-                            android:background="@drawable/button_radius"
-                            android:padding="0dp"
-                            android:paddingLeft="0dp"
-                            android:paddingRight="0dp"
-                            android:text="수정"
-                            android:textColor="@color/white" />
-
-                        <Button
-                            android:id="@+id/buttonDeliveryDelete"
-                            android:layout_width="40dp"
-                            android:layout_height="30dp"
-                            android:layout_marginLeft="10dp"
-                            android:background="@drawable/button_radius"
-                            android:padding="0dp"
-                            android:paddingLeft="0dp"
-                            android:paddingRight="0dp"
-                            android:text="삭제"
-                            android:textColor="@color/white" />
-                    </LinearLayout>
+                        android:textAlignment="textStart" />
 
                 </LinearLayout>
 
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/textViewDeliveryPhone"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="20dp" />
+
+                    <TextView
+                        android:id="@+id/textViewDeliveryAddress"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingTop="20dp">
 
                     <Button
-                        android:id="@+id/buttonDeliverySelect"
+                        android:id="@+id/buttonDeliveryUpdate"
                         android:layout_width="40dp"
                         android:layout_height="30dp"
                         android:background="@drawable/button_radius"
                         android:padding="0dp"
-                        android:text="선택"
-                        android:textColor="@color/white"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                        android:paddingLeft="0dp"
+                        android:paddingRight="0dp"
+                        android:text="수정"
+                        android:textColor="@color/white" />
+
+                    <Button
+                        android:id="@+id/buttonDeliveryDelete"
+                        android:layout_width="40dp"
+                        android:layout_height="30dp"
+                        android:layout_marginLeft="10dp"
+                        android:background="@drawable/button_radius"
+                        android:padding="0dp"
+                        android:paddingLeft="0dp"
+                        android:paddingRight="0dp"
+                        android:text="삭제"
+                        android:textColor="@color/white" />
+                </LinearLayout>
+
             </LinearLayout>
 
-        </androidx.cardview.widget.CardView>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-    </LinearLayout>
-</layout>
+                <Button
+                    android:id="@+id/buttonDeliverySelect"
+                    android:layout_width="40dp"
+                    android:layout_height="30dp"
+                    android:background="@drawable/button_radius"
+                    android:padding="0dp"
+                    android:text="선택"
+                    android:textColor="@color/white"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>
+

--- a/app/src/main/res/layout/row_order_main.xml
+++ b/app/src/main/res/layout/row_order_main.xml
@@ -11,16 +11,72 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
-        android:orientation="horizontal">
-        <ImageView
-            android:id="@+id/imageViewPieceRowOrderMain"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            app:srcCompat="@drawable/mygallery_icon" />
-        <TextView
-            android:id="@+id/textViewRowOrderMain"
+        android:orientation="vertical"
+        android:paddingHorizontal="10dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/textViewRowOrderMainAuthorName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="작가이름"
+                android:textSize="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewRowOrderMainAddDeliveryPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="추가배송비 4,000원"
+                android:textSize="14dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:padding="5dp">
+
+            <ImageView
+                android:id="@+id/imageViewPieceRowOrderMain"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                app:srcCompat="@drawable/mygallery_icon" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="10dp">
+
+                <TextView
+                    android:id="@+id/textViewRowOrderMainPieceName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="작품이름"
+                    android:textSize="18dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/textViewRowOrderMainPiecePrice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="작품가격"
+                    android:textSize="18dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </LinearLayout>
+
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/row_order_main.xml
+++ b/app/src/main/res/layout/row_order_main.xml
@@ -14,31 +14,6 @@
         android:orientation="vertical"
         android:paddingHorizontal="10dp">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <TextView
-                android:id="@+id/textViewRowOrderMainAuthorName"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="작가이름"
-                android:textSize="18dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/textViewRowOrderMainAddDeliveryPrice"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="추가배송비 4,000원"
-                android:textSize="14dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -51,29 +26,52 @@
                 android:layout_height="100dp"
                 app:srcCompat="@drawable/mygallery_icon" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:padding="10dp">
+                android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/textViewRowOrderMainPieceName"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/textViewRowOrderMainAddDeliveryPrice"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="작품이름"
-                    android:textSize="18dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:text="추가배송비 4,000원"
+                    android:textAlignment="textEnd"
+                    android:textSize="14dp" />
 
-                <TextView
-                    android:id="@+id/textViewRowOrderMainPiecePrice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="작품가격"
-                    android:textSize="18dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="5dp">
+
+                    <TextView
+                        android:id="@+id/textViewRowOrderMainPieceName"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="작품이름"
+                        android:textSize="20dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/textViewRowOrderMainAuthorName"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="작가이름"
+                        android:textSize="12dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/textViewRowOrderMainPieceName" />
+
+                    <TextView
+                        android:id="@+id/textViewRowOrderMainPiecePrice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="작품가격"
+                        android:textSize="14dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </LinearLayout>
 
         </LinearLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #134 

## 📝작업 내용
1. 리사이클러뷰 분리(팔로우 어답터, 딜리버리 어답터)
2. 배송지 MVVM 구현
3. 배송지 관리 리사이클러뷰 데이터 연동
4. 배송지 관리 리사이클러뷰 항목 뷰 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/42809017-0876-4cfe-bdb8-de3ee7f2f927)

## 💬리뷰 요구사항(선택)
장바구니는 데이터 연동 나중으로 미루고 배송지관리부터 하고있습니다.
장바구니 데이터 연동할 때 패닉와서 이것저것 했더니 코드 양이 많아졌네요. 다음부턴 잘게 쪼개서 하겠습니다...ㅎ;
