### PR TITLE
[#170] 작가 정보 수정 mvvm 구현 db 연동

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -1,7 +1,9 @@
 package kr.co.lion.unipiece.db.remote
 
+import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
+import com.google.firebase.storage.storage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -11,6 +13,7 @@ import kr.co.lion.unipiece.model.AuthorInfoData
 class AuthorInfoDataSource {
 
     private val db = Firebase.firestore
+    private val storage = Firebase.storage.reference
 
     // 작가 번호 시퀀스값을 가져온다.
     suspend fun getAuthorSequence():Int{
@@ -118,6 +121,17 @@ class AuthorInfoDataSource {
         job1.join()
 
         return authorList
+    }
+
+    // 작가 이미지 url 받아오기
+    suspend fun getAuthorInfoImg(authorImg: String): String? {
+        val path = "AuthorInfo/$authorImg"
+        return try {
+            storage.child(path).downloadUrl.await().toString()
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error getPieceInfoImg: ${e.message} ${path}")
+            null
+        }
     }
 
 

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -81,6 +81,24 @@ class AuthorInfoDataSource {
         return authorInfoData
     }
 
+    // userIdx로 작가 정보를 가져와 반환한다
+    suspend fun getAuthorInfoDataByUserIdx(userIdx:Int) : AuthorInfoData? {
+        var authorInfoData:AuthorInfoData? = null
+
+        val job1 = CoroutineScope(Dispatchers.IO).launch {
+            // AuthorInfo 컬렉션 접근 객체를 가져온다.
+            val collectionReference = db.collection("AuthorInfo")
+            // authorIdx 필드가 매개변수로 들어오는 authorIdx와 같은 문서들을 가져온다.
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+            // 가져온 문서객체들이 들어 있는 리스트에서 첫 번째 객체를 추출한다.
+            // 회원 번호가 동일한 사용는 없기 때문에 무조건 하나만 나오기 때문이다
+            authorInfoData = querySnapshot.documents[0].toObject(AuthorInfoData::class.java)
+        }
+        job1.join()
+
+        return authorInfoData
+    }
+
     // 모든 작가의 정보를 가져온다.
     suspend fun getAuthorInfoAll():MutableList<AuthorInfoData>{
         // 사용자 정보를 담을 리스트

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -81,8 +81,8 @@ class AuthorInfoDataSource {
         return authorInfoData
     }
 
-    // userIdx로 작가 정보를 가져와 반환한다
-    suspend fun getAuthorInfoDataByUserIdx(userIdx:Int) : AuthorInfoData? {
+    // userIdx로 작가Idx를 가져와 반환한다
+    suspend fun getAuthorIdxByUserIdx(userIdx:Int) : Int {
         var authorInfoData:AuthorInfoData? = null
 
         val job1 = CoroutineScope(Dispatchers.IO).launch {
@@ -96,7 +96,7 @@ class AuthorInfoDataSource {
         }
         job1.join()
 
-        return authorInfoData
+        return authorInfoData!!.authorIdx
     }
 
     // 모든 작가의 정보를 가져온다.

--- a/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/model/AuthorInfoData.kt
@@ -9,8 +9,8 @@ data class AuthorInfoData(
     var authorName: String,
     var authorBasic: String,
     var authorInfo: String,
-    var authorSale: String,
+    var authorSale: Int,
     var authorDate: Timestamp,
 ){
-    constructor() : this(0, 0, "", "무명", "OO대학 OO학과", "작가 소개하는 내용", "", Timestamp.now())
+    constructor() : this(0, 0, "", "무명", "OO대학 OO학과", "작가 소개하는 내용", 0, Timestamp.now())
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -18,8 +18,8 @@ class AuthorInfoRepository {
     // 작가 번호를 통해 작가 정보를 가져와 반환한다
     suspend fun getAuthorInfoDataByIdx(authorIdx:Int) = authorInfoDataSource.getAuthorInfoDataByIdx(authorIdx)
 
-    // userIdx로 작가 정보를 가져와 반환한다
-    suspend fun getAuthorInfoByUserIdx(userIdx:Int) = authorInfoDataSource.getAuthorInfoDataByUserIdx(userIdx)
+    // userIdx로 작가idx를 가져와 반환한다
+    suspend fun getAuthorIdxByUserIdx(userIdx:Int) = authorInfoDataSource.getAuthorIdxByUserIdx(userIdx)
 
     // 모든 작가의 정보를 가져온다.
     suspend fun getAuthorInfoAll():MutableList<AuthorInfoData> = authorInfoDataSource.getAuthorInfoAll()

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -24,6 +24,9 @@ class AuthorInfoRepository {
     // 모든 작가의 정보를 가져온다.
     suspend fun getAuthorInfoAll():MutableList<AuthorInfoData> = authorInfoDataSource.getAuthorInfoAll()
 
+    // 작가 이미지 url 받아오기
+    suspend fun getAuthorInfoImg(authorImg:String):String? = authorInfoDataSource.getAuthorInfoImg(authorImg)
+
     // 작가 정보를 수정하는 메서드
     suspend fun updateAuthorInfoData(authorInfoData: AuthorInfoData) = authorInfoDataSource.updateAuthorInfoData(authorInfoData)
 

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -18,6 +18,9 @@ class AuthorInfoRepository {
     // 작가 번호를 통해 작가 정보를 가져와 반환한다
     suspend fun getAuthorInfoDataByIdx(authorIdx:Int) = authorInfoDataSource.getAuthorInfoDataByIdx(authorIdx)
 
+    // userIdx로 작가 정보를 가져와 반환한다
+    suspend fun getAuthorInfoByUserIdx(userIdx:Int) = authorInfoDataSource.getAuthorInfoDataByUserIdx(userIdx)
+
     // 모든 작가의 정보를 가져온다.
     suspend fun getAuthorInfoAll():MutableList<AuthorInfoData> = authorInfoDataSource.getAuthorInfoAll()
 
@@ -35,4 +38,6 @@ class AuthorInfoRepository {
 
     // 작가 팔로우 취소
     suspend fun cancelFollowing(userIdx:Int, authorIdx:Int) = authorInfoDataSource.cancelFollowing(userIdx, authorIdx)
+
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
@@ -5,8 +5,12 @@ import android.os.Bundle
 import android.os.SystemClock
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.databinding.ActivityAuthorInfoBinding
+import kr.co.lion.unipiece.repository.AuthorInfoRepository
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
 
 class AuthorInfoActivity : AppCompatActivity() {
@@ -23,14 +27,21 @@ class AuthorInfoActivity : AppCompatActivity() {
         setContentView(activityAuthorInfoBinding.root)
 
         // 다른 액티비티에서 받아온 작가idx
-        val authorIdx:Int = intent.getIntExtra("authorIdx",0)
+        var authorIdx = intent.getIntExtra("authorIdx",0)
+        lifecycleScope.launch {
+            if(authorIdx == 0){
+                authorIdx = AuthorInfoRepository().getAuthorIdxByUserIdx(
+                    UniPieceApplication.prefs.getUserIdx("userIdx",0)
+                )
+            }
 
-        // 추후 전달할 데이터는 여기에 담기
-        val authorInfoBundle = Bundle()
-        // 작가idx 전달
-        authorInfoBundle.putInt("authorIdx",authorIdx)
+            // 추후 전달할 데이터는 여기에 담기
+            val authorInfoBundle = Bundle()
+            // 작가idx 전달
+            authorInfoBundle.putInt("authorIdx",authorIdx)
 
-        replaceFragment(AuthorInfoFragmentName.AUTHOR_INFO_FRAGMENT, false, authorInfoBundle)
+            replaceFragment(AuthorInfoFragmentName.AUTHOR_INFO_FRAGMENT, false, authorInfoBundle)
+        }
     }
 
     // 프래그먼트 교체 코드

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoActivity.kt
@@ -22,11 +22,13 @@ class AuthorInfoActivity : AppCompatActivity() {
         activityAuthorInfoBinding = ActivityAuthorInfoBinding.inflate(layoutInflater)
         setContentView(activityAuthorInfoBinding.root)
 
+        // 다른 액티비티에서 받아온 작가idx
+        val authorIdx:Int = intent.getIntExtra("authorIdx",0)
+
         // 추후 전달할 데이터는 여기에 담기
         val authorInfoBundle = Bundle()
-        // 이전 액티비티에서 authorIdx를 받아온다.
-        // 수정 필요
-        authorInfoBundle.putInt("authorIdx",1)
+        // 작가idx 전달
+        authorInfoBundle.putInt("authorIdx",authorIdx)
 
         replaceFragment(AuthorInfoFragmentName.AUTHOR_INFO_FRAGMENT, false, authorInfoBundle)
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorInfoFragment.kt
@@ -13,19 +13,17 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.databinding.FragmentAuthorInfoBinding
-import kr.co.lion.unipiece.model.PieceInfoData
-import kr.co.lion.unipiece.repository.PieceInfoRepository
 import kr.co.lion.unipiece.ui.MainActivity
 import kr.co.lion.unipiece.ui.author.adapter.AuthorPiecesAdapter
 import kr.co.lion.unipiece.ui.author.viewmodel.AuthorInfoViewModel
 import kr.co.lion.unipiece.ui.buy.BuyDetailActivity
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
+import kr.co.lion.unipiece.util.setImage
 import kr.co.lion.unipiece.util.setMenuIconColor
 
 class AuthorInfoFragment : Fragment() {
@@ -141,11 +139,11 @@ class AuthorInfoFragment : Fragment() {
                     buttonAuthorFollow.isVisible = false
                     buttonAuthorReview.isVisible = false
                 }
+                // 작가 이미지 셋팅
+                val authorImg = authorInfoViewModel!!.authorInfoData.value?.authorImg
+                val imageUrl = authorInfoViewModel!!.getAuthorInfoImg(authorImg!!)
+                requireActivity().setImage(imageViewAuthor, imageUrl)
             }
-            // 작가 이미지 셋팅
-            Glide.with(requireActivity())
-                .load(authorInfoViewModel!!.authorInfoData.value?.authorImg)
-                .into(imageViewAuthor)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
@@ -6,29 +6,66 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.databinding.FragmentModifyAuthorInfoBinding
+import kr.co.lion.unipiece.ui.author.viewmodel.ModifyAuthorInfoViewModel
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
-import kr.co.lion.unipiece.util.UserInfoFragmentName
+import kr.co.lion.unipiece.util.setImage
 
 class ModifyAuthorInfoFragment : Fragment() {
 
     lateinit var fragmentModifyAuthorInfoBinding: FragmentModifyAuthorInfoBinding
+    private val modifyAuthorInfoViewModel: ModifyAuthorInfoViewModel by viewModels()
+
+    val authorIdx by lazy {
+        requireArguments().getInt("authorIdx")
+    }
+
+    val userIdx by lazy {
+        UniPieceApplication.prefs.getUserIdx("userIdx", 0)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        fragmentModifyAuthorInfoBinding = FragmentModifyAuthorInfoBinding.inflate(inflater)
+        fragmentModifyAuthorInfoBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_modify_author_info, container, false)
+        fragmentModifyAuthorInfoBinding.modifyAuthorInfoViewModel = modifyAuthorInfoViewModel
+        fragmentModifyAuthorInfoBinding.lifecycleOwner = this
 
-        settingToolbar()
-        settingImageViewEvent()
-        settingButtonUpdateAuthor()
-        settingButtonModifyAuthorInfo()
+
+
+        lifecycleScope.launch {
+            fetchData(authorIdx)
+            settingToolbar()
+            settingImageViewEvent()
+            settingButtonUpdateAuthor()
+            settingButtonModifyAuthorInfo()
+        }
+
 
         return fragmentModifyAuthorInfoBinding.root
+    }
+
+
+
+    // 작가 정보 불러오기
+    private fun fetchData(authorIdx:Int){
+        lifecycleScope.launch {
+            modifyAuthorInfoViewModel.getAuthorInfoData(authorIdx)
+
+            // 작가 이미지 셋팅
+            val authorImg = modifyAuthorInfoViewModel.authorInfoData.value?.authorImg
+            val imageUrl = modifyAuthorInfoViewModel.getAuthorInfoImg(authorImg!!)
+            requireActivity().setImage(fragmentModifyAuthorInfoBinding.imageViewModifyAuthor, imageUrl)
+        }
     }
 
     // 툴바 셋팅
@@ -57,6 +94,7 @@ class ModifyAuthorInfoFragment : Fragment() {
         fragmentModifyAuthorInfoBinding.buttonModifyAuthorUpdateAuthor.setOnClickListener {
             // 작가 갱신 액티비티로 이동
             val updateAuthorIntent = Intent(requireActivity(), UpdateAuthorActivity::class.java)
+            updateAuthorIntent.putExtra("authorIdx", authorIdx)
             startActivity(updateAuthorIntent)
         }
     }
@@ -65,7 +103,11 @@ class ModifyAuthorInfoFragment : Fragment() {
     private fun settingButtonModifyAuthorInfo(){
         fragmentModifyAuthorInfoBinding.buttonModifyAuthorInfoConfirm.setOnClickListener {
             // 추후 수정
-            removeFragment()
+            lifecycleScope.launch {
+                modifyAuthorInfoViewModel.updateAuthorInfo()
+                removeFragment()
+            }
+
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/AuthorInfoViewModel.kt
@@ -89,4 +89,9 @@ class AuthorInfoViewModel: ViewModel() {
         _authorPieces.value = pieceInfoList
     }
 
+    // 작가의 이미지 URL 가져오기
+    suspend fun getAuthorInfoImg(authorImg:String):String?{
+        return authorInfoRepository.getAuthorInfoImg(authorImg)
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
@@ -1,0 +1,39 @@
+package kr.co.lion.unipiece.ui.author.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.model.AuthorInfoData
+import kr.co.lion.unipiece.repository.AuthorInfoRepository
+
+class ModifyAuthorInfoViewModel: ViewModel() {
+    // 작가 정보
+    private val _authorInfoData = MutableLiveData<AuthorInfoData>()
+    val authorInfoData: LiveData<AuthorInfoData> = _authorInfoData
+
+    private val authorInfoRepository = AuthorInfoRepository()
+
+    // 작가 정보를 불러오기
+    suspend fun getAuthorInfoData(authorIdx: Int) {
+        val job1 = viewModelScope.launch {
+            // 작가 정보 객체 셋팅
+            _authorInfoData.value = authorInfoRepository.getAuthorInfoDataByIdx(authorIdx)
+        }
+        job1.join()
+    }
+
+    // 작가의 이미지 URL 가져오기
+    suspend fun getAuthorInfoImg(authorImg:String):String?{
+        return authorInfoRepository.getAuthorInfoImg(authorImg)
+    }
+
+    // 작가 이미지 셋팅
+
+
+    // 작가 정보 수정
+    suspend fun updateAuthorInfo(){
+        authorInfoRepository.updateAuthorInfoData(authorInfoData.value!!)
+    }
+}

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
@@ -9,6 +9,7 @@ import kr.co.lion.unipiece.model.AuthorInfoData
 import kr.co.lion.unipiece.repository.AuthorInfoRepository
 
 class ModifyAuthorInfoViewModel: ViewModel() {
+
     // 작가 정보
     private val _authorInfoData = MutableLiveData<AuthorInfoData>()
     val authorInfoData: LiveData<AuthorInfoData> = _authorInfoData

--- a/app/src/main/res/layout/fragment_modify_author_info.xml
+++ b/app/src/main/res/layout/fragment_modify_author_info.xml
@@ -1,131 +1,143 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
-    tools:context=".ui.author.ModifyAuthorInfoFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbarModifyAuthorInfo"
+    <data>
+        <variable
+            name="modifyAuthorInfoViewModel"
+            type="kr.co.lion.unipiece.ui.author.viewmodel.ModifyAuthorInfoViewModel" />
+    </data>
+
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="64dp"
-        android:background="@color/white"
-        android:minHeight="?attr/actionBarSize"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:theme="?attr/actionBarTheme"
-        app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+        android:layout_height="match_parent"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:orientation="vertical"
+        tools:context=".ui.author.ModifyAuthorInfoFragment">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-
-        <LinearLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarModifyAuthorInfo"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="20dp">
+            android:layout_height="64dp"
+            android:background="@color/white"
+            android:minHeight="?attr/actionBarSize"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:theme="?attr/actionBarTheme"
+            app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                android:orientation="horizontal">
+                android:orientation="vertical"
+                android:padding="20dp">
 
-                <androidx.cardview.widget.CardView
-                    android:id="@+id/cardViewImageModifyAuthor"
-                    android:layout_width="100dp"
-                    android:layout_height="100dp"
-                    android:layout_gravity="center"
-                    app:cardCornerRadius="50dp">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="horizontal">
 
-                    <ImageView
-                        android:id="@+id/imageViewModifyAuthor"
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/cardViewImageModifyAuthor"
+                        android:layout_width="100dp"
+                        android:layout_height="100dp"
+                        android:layout_gravity="center"
+                        app:cardCornerRadius="50dp">
+
+                        <ImageView
+                            android:id="@+id/imageViewModifyAuthor"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:src="@drawable/ic_launcher_background" />
+                    </androidx.cardview.widget.CardView>
+
+                </LinearLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:hint="작가 이름"
+                    app:boxStrokeColor="@color/second"
+                    app:cursorColor="@color/second"
+                    app:hintTextColor="@color/second">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textInputModifyAuthorName"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:src="@drawable/ic_launcher_background" />
-                </androidx.cardview.widget.CardView>
+                        android:layout_height="56dp"
+                        android:background="@drawable/textfield_radius"
+                        android:inputType="text"
+                        android:paddingLeft="10dp"
+                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorName}"/>
+                </com.google.android.material.textfield.TextInputLayout>
 
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:hint="기본 정보"
+                    app:boxStrokeColor="@color/second"
+                    app:cursorColor="@color/second"
+                    app:hintTextColor="@color/second">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textInputModifyAuthorBasicInfo"
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp"
+                        android:background="@drawable/textfield_radius"
+                        android:inputType="text"
+                        android:paddingLeft="10dp"
+                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorBasic}"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:hint="작가 소개"
+                    app:boxStrokeColor="@color/second"
+                    app:cursorColor="@color/second"
+                    app:hintTextColor="@color/second">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textInputModifyAuthorDetailInfo"
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp"
+                        android:background="@drawable/textfield_radius"
+                        android:inputType="text|textMultiLine"
+                        android:paddingLeft="10dp"
+                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorInfo}"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Button
+                    android:id="@+id/buttonModifyAuthorUpdateAuthor"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="32dp"
+                    android:background="@drawable/button_radius"
+                    android:text="작가 갱신하기"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    app:cornerRadius="15dp" />
+
+                <Button
+                    android:id="@+id/buttonModifyAuthorInfoConfirm"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="32dp"
+                    android:background="@drawable/button_radius"
+                    android:text="수정하기"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    app:cornerRadius="15dp" />
             </LinearLayout>
+        </ScrollView>
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:hint="작가 이름"
-                app:boxStrokeColor="@color/second"
-                app:cursorColor="@color/second"
-                app:hintTextColor="@color/second">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/textInputModifyAuthorName"
-                    android:layout_width="match_parent"
-                    android:layout_height="56dp"
-                    android:background="@drawable/textfield_radius"
-                    android:inputType="text"
-                    android:paddingLeft="10dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:hint="기본 정보"
-                app:boxStrokeColor="@color/second"
-                app:cursorColor="@color/second"
-                app:hintTextColor="@color/second">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/textInputModifyAuthorBasicInfo"
-                    android:layout_width="match_parent"
-                    android:layout_height="56dp"
-                    android:background="@drawable/textfield_radius"
-                    android:inputType="text"
-                    android:paddingLeft="10dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:hint="작가 소개"
-                app:boxStrokeColor="@color/second"
-                app:cursorColor="@color/second"
-                app:hintTextColor="@color/second">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/textInputModifyAuthorDetailInfo"
-                    android:layout_width="match_parent"
-                    android:layout_height="56dp"
-                    android:background="@drawable/textfield_radius"
-                    android:inputType="text|textMultiLine"
-                    android:paddingLeft="10dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Button
-                android:id="@+id/buttonModifyAuthorUpdateAuthor"
-                android:layout_width="match_parent"
-                android:layout_height="40dp"
-                android:layout_marginTop="32dp"
-                android:background="@drawable/button_radius"
-                android:text="작가 갱신하기"
-                android:textColor="@color/white"
-                android:textSize="18sp"
-                app:cornerRadius="15dp" />
-
-            <Button
-                android:id="@+id/buttonModifyAuthorInfoConfirm"
-                android:layout_width="match_parent"
-                android:layout_height="40dp"
-                android:layout_marginTop="32dp"
-                android:background="@drawable/button_radius"
-                android:text="수정하기"
-                android:textColor="@color/white"
-                android:textSize="18sp"
-                app:cornerRadius="15dp" />
-        </LinearLayout>
-    </ScrollView>
-
-</LinearLayout>
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #170 

## 📝작업 내용

> 작가 정보 수정 관련 작업했습니다
> 이미지 수정은 아직 미구현으로 새 이슈 발행후 이어서 작업하겠습니다
> AuthorInfoData에 sale프로퍼티 타입이 String으로 되어있어서 Int로 수정했습니다
> AuthorInfoActivity에서 authorIdx 받고, 전달받은 authorIdx가 없는 경우에는 마이페이지에서 온 경우로 체크합니다

### 스크린샷 (선택)
[modifyauthor.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/6ede7f87-99b7-42f4-afff-bd3591a1b3d1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
