### PR TITLE
[#175] 작가 정보 기본 이미지 변경

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorPiecesAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/adapter/AuthorPiecesAdapter.kt
@@ -3,6 +3,9 @@ package kr.co.lion.unipiece.ui.author.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.databinding.RowAuthorPiecesBinding
 import kr.co.lion.unipiece.model.PieceInfoData
 import kr.co.lion.unipiece.util.setImage
@@ -21,10 +24,12 @@ class AuthorPiecesAdapter(val pieceInfoList: List<PieceInfoData>, private val it
 
     override fun onBindViewHolder(holder: AuthorPiecesViewHolder, position: Int) {
         // 이미지
-        holder.rowAuthorPiecesBinding.root.context.setImage(
-            holder.rowAuthorPiecesBinding.imageViewAuthorPiece,
-            pieceInfoList[position].pieceImg
-        )
+        CoroutineScope(Dispatchers.Main).launch{
+            holder.rowAuthorPiecesBinding.root.context.setImage(
+                holder.rowAuthorPiecesBinding.imageViewAuthorPiece,
+                pieceInfoList[position].pieceImg
+            )
+        }
         // 작품 클릭 시 설명 화면 이동
         holder.rowAuthorPiecesBinding.root.setOnClickListener {
             itemClickListener(pieceInfoList[position].pieceIdx)

--- a/app/src/main/res/layout/fragment_author_info.xml
+++ b/app/src/main/res/layout/fragment_author_info.xml
@@ -53,7 +53,7 @@
                             android:id="@+id/imageViewAuthor"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
-                            android:src="@drawable/ic_launcher_background" />
+                            android:src="@drawable/icon" />
                     </androidx.cardview.widget.CardView>
 
                     <LinearLayout

--- a/app/src/main/res/layout/fragment_modify_author_info.xml
+++ b/app/src/main/res/layout/fragment_modify_author_info.xml
@@ -53,7 +53,7 @@
                             android:id="@+id/imageViewModifyAuthor"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
-                            android:src="@drawable/ic_launcher_background" />
+                            android:src="@drawable/icon" />
                     </androidx.cardview.widget.CardView>
 
                 </LinearLayout>

--- a/app/src/main/res/layout/row_author_pieces.xml
+++ b/app/src/main/res/layout/row_author_pieces.xml
@@ -16,6 +16,6 @@
             android:id="@+id/imageViewAuthorPiece"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:src="@drawable/ic_launcher_background" />
+            android:src="@drawable/icon" />
     </androidx.cardview.widget.CardView>
 </LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #175 

## 📝작업 내용

> 작가 정보, 리사이클러뷰 아이템, 작가 수정에서 이미지뷰의 기본 이미지를 앱 로고로 변경했습니다

### 스크린샷 (선택)
![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/873d6c64-f4ad-4527-b48a-eb6ef32f0eec)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
