### PR TITLE
[#186] 작품 모아보기 viewmodel, fragment 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.GravityCompat
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
@@ -30,7 +30,7 @@ class BuyFragment : Fragment() {
 
     private lateinit var callback: OnBackPressedCallback
 
-    private val viewModel: BuyViewModel by activityViewModels()
+    private val viewModel: BuyViewModel by viewModels()
 
     var currentFragment : Int = -1
 
@@ -347,7 +347,7 @@ class BuyFragment : Fragment() {
     fun initViewPager() {
 
         val titles = listOf("인기 순", "신규 순")
-        val vpAdapter = BuyAdapter(requireActivity())
+        val vpAdapter = BuyAdapter(this)
         vpAdapter.addFragment(BuyPopFragment())
         vpAdapter.addFragment(BuyNewFragment())
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -136,6 +136,10 @@ class BuyFragment : Fragment() {
                     drawerBuyLayout.close()
                     it.isChecked = true
 
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        viewModel.loading()
+                    }
+
                     when(it.itemId){
                         R.id.menuAll -> {
                             when(currentFragment){

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.GravityCompat
+import androidx.core.view.forEach
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
@@ -34,6 +35,11 @@ class BuyFragment : Fragment() {
 
     var currentFragment : Int = -1
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        callBack()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -49,11 +55,6 @@ class BuyFragment : Fragment() {
         settingToolbarBuy()
         initViewPager()
         setBuyNaviDrawer()
-    }
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        callBack()
     }
 
     override fun onDetach() {
@@ -124,6 +125,7 @@ class BuyFragment : Fragment() {
             }
 
             with(navigationDrawer){
+
                 val headerDrawerBinding = HeaderBuyDrawerBinding.inflate(layoutInflater)
                 addHeaderView(headerDrawerBinding.root)
 
@@ -134,20 +136,24 @@ class BuyFragment : Fragment() {
                 setNavigationItemSelectedListener {
 
                     drawerBuyLayout.close()
-                    it.isChecked = true
 
                     viewLifecycleOwner.lifecycleScope.launch {
-                        viewModel.loading()
+                        viewModel.popLoading(true)
+                        viewModel.newLoading(true)
                     }
+
+                    it.setChecked(true)
 
                     when(it.itemId){
                         R.id.menuAll -> {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceInfo()
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceInfo()
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -155,9 +161,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceSort("예술 대학")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceSort("예술 대학")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -165,9 +173,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("서양화")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("서양화")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -175,9 +185,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("동양화")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("동양화")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -185,9 +197,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("서예")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("서예")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -195,9 +209,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("조소")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("조소")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -205,9 +221,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("판화")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("판화")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -215,9 +233,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("가구/목재")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("가구/목재")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -225,9 +245,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("도자기/유리")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("도자기/유리")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -235,9 +257,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("섬유/염색")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("섬유/염색")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -245,9 +269,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("금속")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("금속")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -255,9 +281,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("만화")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("만화")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -265,9 +293,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("애니메이션")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("애니메이션")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -275,9 +305,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceSort("인문 대학")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceSort("인문 대학")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -285,9 +317,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("소설")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("소설")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -295,9 +329,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("시")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("시")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -305,9 +341,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("극본")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("극본")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -315,9 +353,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceSort("공과 대학")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceSort("공과 대학")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -325,9 +365,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("소프트웨어")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("소프트웨어")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }
@@ -335,9 +377,11 @@ class BuyFragment : Fragment() {
                             when(currentFragment){
                                 0 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getPopPieceDetailSort("하드웨어")
+                                    viewModel.popLoading(false)
                                 }
                                 1 -> viewLifecycleOwner.lifecycleScope.launch {
                                     viewModel.getNewPieceDetailSort("하드웨어")
+                                    viewModel.newLoading(false)
                                 }
                             }
                         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
@@ -2,12 +2,11 @@ package kr.co.lion.unipiece.ui.buy
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
@@ -22,7 +21,7 @@ class BuyNewFragment : Fragment() {
 
     lateinit var binding: FragmentBuyNewBinding
 
-    private val viewModel: BuyViewModel by activityViewModels()
+    private val viewModel: BuyViewModel by viewModels( ownerProducer = { requireParentFragment()} )
 
     val buyNewAdapter : BuyNewAdapter by lazy {
         BuyNewAdapter(

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
@@ -71,9 +71,13 @@ class BuyNewFragment : Fragment() {
     fun setLoading(){
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.loadingData.observe(viewLifecycleOwner, Observer { value ->
-                    binding.buyNewRV.scrollToPosition(0)
-                    binding.progressBar.visibility = View.VISIBLE
+                viewModel.newLoading.observe(viewLifecycleOwner, Observer { value ->
+                    if(value){
+                        binding.buyNewRV.scrollToPosition(0)
+                        binding.progressBar.visibility = View.VISIBLE
+                    } else {
+                        binding.progressBar.visibility = View.GONE
+                    }
                 })
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyNewFragment.kt
@@ -48,6 +48,7 @@ class BuyNewFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initView()
+        setLoading()
     }
 
     fun initView() {
@@ -60,7 +61,19 @@ class BuyNewFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.newPieceInfoList.observe(viewLifecycleOwner, Observer { value ->
+                    binding.progressBar.visibility = View.GONE
                     buyNewAdapter.updateData(value)
+                })
+            }
+        }
+    }
+
+    fun setLoading(){
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.loadingData.observe(viewLifecycleOwner, Observer { value ->
+                    binding.buyNewRV.scrollToPosition(0)
+                    binding.progressBar.visibility = View.VISIBLE
                 })
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
@@ -70,9 +70,13 @@ class BuyPopFragment : Fragment() {
     fun setLoading(){
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.loadingData.observe(viewLifecycleOwner, Observer { value ->
-                    binding.buyPopRV.scrollToPosition(0)
-                    binding.progressBar.visibility = View.VISIBLE
+                viewModel.popLoading.observe(viewLifecycleOwner, Observer { value ->
+                    if(value){
+                        binding.buyPopRV.scrollToPosition(0)
+                        binding.progressBar.visibility = View.VISIBLE
+                    } else {
+                        binding.progressBar.visibility = View.GONE
+                    }
                 })
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
@@ -47,6 +47,7 @@ class BuyPopFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initView()
+        setLoading()
     }
 
     fun initView() {
@@ -59,7 +60,19 @@ class BuyPopFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.popPieceInfoList.observe(viewLifecycleOwner, Observer { value ->
+                    binding.progressBar.visibility = View.GONE
                     buyPopAdapter.updateData(value)
+                })
+            }
+        }
+    }
+
+    fun setLoading(){
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.loadingData.observe(viewLifecycleOwner, Observer { value ->
+                    binding.buyPopRV.scrollToPosition(0)
+                    binding.progressBar.visibility = View.VISIBLE
                 })
             }
         }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/BuyPopFragment.kt
@@ -2,12 +2,11 @@ package kr.co.lion.unipiece.ui.buy
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
@@ -22,7 +21,7 @@ class BuyPopFragment : Fragment() {
 
     lateinit var binding: FragmentBuyPopBinding
 
-    private val viewModel: BuyViewModel by activityViewModels()
+    private val viewModel: BuyViewModel by viewModels( ownerProducer = { requireParentFragment()} )
 
     val buyPopAdapter: BuyPopAdapter by lazy {
         BuyPopAdapter(

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyAdapter.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class BuyAdapter (fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity) {
+class BuyAdapter (fragment: Fragment) : FragmentStateAdapter(fragment.childFragmentManager, fragment.lifecycle)  {
     var fragments: ArrayList<Fragment> = ArrayList()
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyNewAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyNewAdapter.kt
@@ -5,6 +5,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.databinding.ItemBuyBinding
 import kr.co.lion.unipiece.model.PieceInfoData
 import kr.co.lion.unipiece.util.setImage
@@ -41,12 +44,13 @@ class BuyNewViewHolder(val binding: ItemBuyBinding, private val itemClickListene
             pieceName.text = item.pieceName
             piecePrice.text = "${price}원"
 
-            root.context.setImage(pieceImg, item.pieceImg)
-        }
+            // 클릭 리스너 설정, 클릭 시 pieceIdx 전달
+            root.setOnClickListener {
+                itemClickListener.invoke(item.pieceIdx, item.authorIdx)
+            }
 
-        // 클릭 리스너 설정, 클릭 시 pieceIdx 전달
-        binding.root.setOnClickListener {
-            itemClickListener.invoke(item.pieceIdx, item.authorIdx)
+           root.context.setImage(pieceImg, item.pieceImg)
+
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyPopAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/adapter/BuyPopAdapter.kt
@@ -5,6 +5,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.databinding.ItemBuyBinding
 import kr.co.lion.unipiece.model.PieceInfoData
 import kr.co.lion.unipiece.model.SearchResultData
@@ -43,13 +46,13 @@ class BuyPopViewHolder(val binding: ItemBuyBinding, private val itemClickListene
             pieceName.text = item.pieceName
             piecePrice.text = "${price}원"
 
+            // 클릭 리스너 설정, 클릭 시 pieceIdx 전달
+            root.setOnClickListener {
+                itemClickListener.invoke(item.pieceIdx, item.authorIdx)
+            }
+
             root.context.setImage(pieceImg, item.pieceImg)
 
-        }
-
-        // 클릭 리스너 설정, 클릭 시 pieceIdx 전달
-        binding.root.setOnClickListener {
-            itemClickListener.invoke(item.pieceIdx, item.authorIdx)
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/viewmodel/BuyViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/viewmodel/BuyViewModel.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.buy.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -18,8 +19,11 @@ class BuyViewModel(): ViewModel() {
     private val _newPieceInfoList = MutableLiveData<List<PieceInfoData>>()
     val newPieceInfoList : LiveData<List<PieceInfoData>> = _newPieceInfoList
 
-    private val _loadingData: MutableLiveData<Unit> = MutableLiveData()
-    val loadingData: LiveData<Unit> = _loadingData
+    private val _popLoading: MutableLiveData<Boolean> = MutableLiveData()
+    val popLoading: LiveData<Boolean> = _popLoading
+
+    private val _newLoading: MutableLiveData<Boolean> = MutableLiveData()
+    val newLoading: LiveData<Boolean> = _newLoading
 
     init {
         viewModelScope.launch {
@@ -28,8 +32,12 @@ class BuyViewModel(): ViewModel() {
         }
     }
 
-    fun loading(){
-        _loadingData.value = Unit
+    fun popLoading(check: Boolean){
+        _popLoading.value = check
+    }
+
+    fun newLoading(check: Boolean){
+        _newLoading.value = check
     }
 
     suspend fun getPopPieceInfo(){
@@ -56,6 +64,7 @@ class BuyViewModel(): ViewModel() {
         }
 
         _newPieceInfoList.value = pieceInfoList
+        Log.d("buy new", _newPieceInfoList.value.toString())
     }
 
     suspend fun getPopPieceSort(category: String){
@@ -95,6 +104,7 @@ class BuyViewModel(): ViewModel() {
         }
 
         _newPieceInfoList.value = pieceInfoList
+        Log.d("buy new sort", _newPieceInfoList.value.toString())
     }
 
     suspend fun getNewPieceDetailSort(detailCategory: String){
@@ -108,6 +118,7 @@ class BuyViewModel(): ViewModel() {
         }
 
         _newPieceInfoList.value = pieceInfoList
+        Log.d("buy new detail sort", _newPieceInfoList.value.toString())
     }
 
     private suspend fun getPieceImg(pieceIdx: String, pieceImg: String): String? {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/buy/viewmodel/BuyViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/buy/viewmodel/BuyViewModel.kt
@@ -18,11 +18,18 @@ class BuyViewModel(): ViewModel() {
     private val _newPieceInfoList = MutableLiveData<List<PieceInfoData>>()
     val newPieceInfoList : LiveData<List<PieceInfoData>> = _newPieceInfoList
 
+    private val _loadingData: MutableLiveData<Unit> = MutableLiveData()
+    val loadingData: LiveData<Unit> = _loadingData
+
     init {
         viewModelScope.launch {
             getPopPieceInfo()
             getNewPieceInfo()
         }
+    }
+
+    fun loading(){
+        _loadingData.value = Unit
     }
 
     suspend fun getPopPieceInfo(){

--- a/app/src/main/res/layout/activity_buy_detail.xml
+++ b/app/src/main/res/layout/activity_buy_detail.xml
@@ -38,8 +38,7 @@
                 android:id="@+id/pieceImg"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:scaleType="fitXY"
-                android:src="@drawable/icon" />
+                android:scaleType="fitXY"/>
 
             <TextView
                 android:id="@+id/authorName"

--- a/app/src/main/res/layout/fragment_buy_new.xml
+++ b/app/src/main/res/layout/fragment_buy_new.xml
@@ -2,8 +2,17 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     android:padding="20dp">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="50dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/first" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/buyNewRV"

--- a/app/src/main/res/layout/fragment_buy_pop.xml
+++ b/app/src/main/res/layout/fragment_buy_pop.xml
@@ -2,9 +2,18 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     android:padding="20dp"
     tools:context=".ui.buy.BuyPopFragment">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="50dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/first" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/buyPopRV"

--- a/app/src/main/res/layout/item_buy.xml
+++ b/app/src/main/res/layout/item_buy.xml
@@ -10,8 +10,7 @@
         android:id="@+id/pieceImg"
         android:layout_width="150dp"
         android:layout_height="150dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/ic_launcher_background" />
+        android:scaleType="centerCrop"/>
 
     <TextView
         android:id="@+id/authorName"

--- a/app/src/main/res/menu/menu_buy_drawer.xml
+++ b/app/src/main/res/menu/menu_buy_drawer.xml
@@ -4,8 +4,7 @@
     <item
         android:id="@+id/menuAll"
         android:checkable="true"
-        android:title="전체 보기"
-        android:checked="true"/>
+        android:title="전체 보기" />
     <item
         android:id="@+id/menuArtUni"
         android:title="예술 대학">
@@ -13,7 +12,7 @@
             <item
                 android:id="@+id/menuArtAll"
                 android:checkable="true"
-                android:title="예술 대학 전체"/>
+                android:title="예술 대학 전체" />
             <item
                 android:id="@+id/menuArtWest"
                 android:checkable="true"


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Refactor] BuyFragment 작품 모아보기 수정 #186

## 📝작업 내용

> - BuyFragment, BuyPopFragment, BuyNewFragment Viewmodel 선언 수정
=> fragment 끼리 부모-자식 관계로 수정해주었습니다. (BuyFragment 안에 BuyPop / BuyNew 두개의 Fragment가 존재)
> - BuyPopFragment, BuyNewFragment 데이터 로딩 부분 수정
=> 코루틴으로 해결하려고 했으나, 상품 데이터가 많으므로 전체 데이터를 불러와서 recylcerview에 넣는거 자체가 오래걸려서 progressbar를 추가해서 해결해주었습니다.

### 스크린샷 (선택)


https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/69308068/fe8d7841-0b36-4084-ad22-3ce5362c657a

