### PR TITLE
[#178] 작가 정보 수정 기능 중 이미지 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -258,12 +258,12 @@ class AuthorInfoDataSource {
     }
 
     // 작가 이미지 파일 업로드
-    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean {
+    suspend fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean {
         val imageFileName = "${authorIdx}.jpg"
         val imageRef = storage.child("AuthorInfo/$imageFileName")
 
         return try {
-            imageRef.putFile(imageUri)
+            imageRef.putFile(imageUri).await()
             true
         } catch (e: Exception) {
             Log.e("Firebase Error", "Error uploadImage: ${e.message}")

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.db.remote
 
+import android.net.Uri
 import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
@@ -253,6 +254,20 @@ class AuthorInfoDataSource {
         } catch (e: Exception) {
             Log.e("Firebase Error", "Error getPieceInfoImg: ${e.message} ${path}")
             null
+        }
+    }
+
+    // 작가 이미지 파일 업로드
+    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean {
+        val imageFileName = "${authorIdx}.jpg"
+        val imageRef = storage.child("AuthorInfo/$imageFileName")
+
+        return try {
+            imageRef.putFile(imageUri)
+            true
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error uploadImage: ${e.message}")
+            false
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -50,5 +50,5 @@ class AuthorInfoRepository {
     suspend fun getAuthorInfoImg(authorIdx: Int) = authorInfoDataSource.getAuthorIdxImg(authorIdx)
 
     // 작가 이미지 파일 업로드
-    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean = authorInfoDataSource.uploadImage(authorIdx, imageUri)
+    suspend fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean = authorInfoDataSource.uploadImage(authorIdx, imageUri)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.repository
 
+import android.net.Uri
 import kr.co.lion.unipiece.db.remote.AuthorInfoDataSource
 import kr.co.lion.unipiece.model.AuthorInfoData
 
@@ -47,4 +48,7 @@ class AuthorInfoRepository {
 
     // 작가 이미지 url 작가 idx로 받아오기
     suspend fun getAuthorInfoImg(authorIdx: Int) = authorInfoDataSource.getAuthorIdxImg(authorIdx)
+
+    // 작가 이미지 파일 업로드
+    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean = authorInfoDataSource.uploadImage(authorIdx, imageUri)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
@@ -1,11 +1,19 @@
 package kr.co.lion.unipiece.ui.author
 
+import android.app.AlertDialog
+import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
@@ -16,7 +24,13 @@ import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.databinding.FragmentModifyAuthorInfoBinding
 import kr.co.lion.unipiece.ui.author.viewmodel.ModifyAuthorInfoViewModel
 import kr.co.lion.unipiece.util.AuthorInfoFragmentName
+import kr.co.lion.unipiece.util.getDegree
+import kr.co.lion.unipiece.util.getPictureUri
+import kr.co.lion.unipiece.util.resize
+import kr.co.lion.unipiece.util.rotate
 import kr.co.lion.unipiece.util.setImage
+import java.io.File
+import kotlin.text.Typography.degree
 
 class ModifyAuthorInfoFragment : Fragment() {
 
@@ -31,6 +45,15 @@ class ModifyAuthorInfoFragment : Fragment() {
         UniPieceApplication.prefs.getUserIdx("userIdx", 0)
     }
 
+    // 카메라, 앨범 실행을 위한 런처
+    lateinit var cameraLauncher: ActivityResultLauncher<Intent>
+    lateinit var albumLauncher: ActivityResultLauncher<Intent>
+
+    // 촬영한 사진이 저장될 경로
+    val imageUri:Uri by lazy{
+        requireActivity().getPictureUri("kr.co.lion.unipiece.file_provider")
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -40,7 +63,8 @@ class ModifyAuthorInfoFragment : Fragment() {
         fragmentModifyAuthorInfoBinding.modifyAuthorInfoViewModel = modifyAuthorInfoViewModel
         fragmentModifyAuthorInfoBinding.lifecycleOwner = this
 
-
+        settingCameraLauncher()
+        settingAlbumLauncher()
 
         lifecycleScope.launch {
             fetchData(authorIdx)
@@ -62,9 +86,11 @@ class ModifyAuthorInfoFragment : Fragment() {
             modifyAuthorInfoViewModel.getAuthorInfoData(authorIdx)
 
             // 작가 이미지 셋팅
-            val authorImg = modifyAuthorInfoViewModel.authorInfoData.value?.authorImg
-            val imageUrl = modifyAuthorInfoViewModel.getAuthorInfoImg(authorImg!!)
-            requireActivity().setImage(fragmentModifyAuthorInfoBinding.imageViewModifyAuthor, imageUrl)
+            if(modifyAuthorInfoViewModel.authorInfoData.value != null){
+                val authorImg = modifyAuthorInfoViewModel.authorInfoData.value!!.authorImg
+                val imageUrl = modifyAuthorInfoViewModel.getAuthorInfoImg(authorImg)
+                requireActivity().setImage(fragmentModifyAuthorInfoBinding.imageViewModifyAuthor, imageUrl)
+            }
         }
     }
 
@@ -72,7 +98,6 @@ class ModifyAuthorInfoFragment : Fragment() {
     private fun settingToolbar() {
         fragmentModifyAuthorInfoBinding.apply {
             toolbarModifyAuthorInfo.apply {
-
                 setNavigationIcon(R.drawable.back_icon)
                 setNavigationOnClickListener {
                     removeFragment()
@@ -83,10 +108,86 @@ class ModifyAuthorInfoFragment : Fragment() {
 
     // 이미지 뷰 클릭 시 사진 변경
     private fun settingImageViewEvent(){
-        fragmentModifyAuthorInfoBinding.imageViewModifyAuthor.setOnClickListener {
-            // 추후 수정
-            removeFragment()
+        with(fragmentModifyAuthorInfoBinding){
+            imageViewModifyAuthor.setOnClickListener {
+                changeAuthorImage()
+            }
+            buttonModifyAuthorImage.setOnClickListener {
+                changeAuthorImage()
+            }
         }
+    }
+
+    // 앨범에서 가져올지 사진을 찍어서 가져올지 확인하는 다이얼로그
+    private fun changeAuthorImage(){
+        val dialog = AlertDialog.Builder(requireActivity())
+        dialog.setTitle("이미지 변경 방법 선택")
+        val items = arrayOf("카메라", "앨범")
+        dialog.setItems(items, DialogInterface.OnClickListener { dialogInterface, i ->
+            when(i){
+                // 카메라 런처 실행
+                0 -> { startCameraLauncher() }
+                // 앨범 런처 실행
+                1 -> { startAlbumLauncher() }
+            }
+        })
+        dialog.show()
+    }
+
+    // 카메라 런처 설정
+    fun settingCameraLauncher(){
+        val contract1 = ActivityResultContracts.StartActivityForResult()
+        cameraLauncher = registerForActivityResult(contract1){
+            // 사진을 사용하겠다고 한 다음에 돌아왔을 경우
+            if(it.resultCode == AppCompatActivity.RESULT_OK){
+                // 회전 각도값을 구한다.
+                val degree = requireActivity().getDegree(imageUri)
+
+                // 사진 객체를 생성한다.
+                val bitmap = BitmapFactory
+                    .decodeFile(imageUri.path)
+                    .rotate(degree.toFloat())
+                    .resize(150)
+
+                // 파이어베이스 스토리지에 업로드
+                
+                // 업로드한 이미지 url 구하기
+                
+                // 파이어베이스 스토어에서 AuthorInfo의 authorImage값 업데이트
+                
+                // 이미지뷰에 변경된 이미지로 셋팅
+                // requireActivity().setImage(fragmentModifyAuthorInfoBinding.imageViewModifyAuthor, imageUri)
+                fragmentModifyAuthorInfoBinding.imageViewModifyAuthor.setImageBitmap(bitmap)
+
+                // 임시 파일을 삭제한다.
+                val file = imageUri.path?.let { it1 -> File(it1) }
+                file?.delete()
+            }
+        }
+    }
+
+    // 카메라 런처를 실행하는 메서드
+    fun startCameraLauncher(){
+        if(imageUri != null){
+            // 실행할 액티비티를 카메라 액티비티로 지정한다.
+            // 단말기에 설치되어 있는 모든 애플리케이션이 가진 액티비티 중에 사진촬영이
+            // 가능한 액티비가 실행된다.
+            val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+            // 이미지가 저장될 경로를 가지고 있는 Uri 객체를 인텐트에 담아준다.
+            cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
+            // 카메라 액티비티 실행
+            cameraLauncher.launch(cameraIntent)
+        }
+    }
+
+    // 앨범 런처 설정
+    fun settingAlbumLauncher(){
+
+    }
+
+    // 카메라 런처를 실행하는 메서드
+    fun startAlbumLauncher(){
+
     }
 
     // 작가 갱신 버튼

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
@@ -30,7 +30,6 @@ import kr.co.lion.unipiece.util.resize
 import kr.co.lion.unipiece.util.rotate
 import kr.co.lion.unipiece.util.setImage
 import java.io.File
-import kotlin.text.Typography.degree
 
 class ModifyAuthorInfoFragment : Fragment() {
 
@@ -168,16 +167,14 @@ class ModifyAuthorInfoFragment : Fragment() {
 
     // 카메라 런처를 실행하는 메서드
     fun startCameraLauncher(){
-        if(imageUri != null){
-            // 실행할 액티비티를 카메라 액티비티로 지정한다.
-            // 단말기에 설치되어 있는 모든 애플리케이션이 가진 액티비티 중에 사진촬영이
-            // 가능한 액티비가 실행된다.
-            val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-            // 이미지가 저장될 경로를 가지고 있는 Uri 객체를 인텐트에 담아준다.
-            cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
-            // 카메라 액티비티 실행
-            cameraLauncher.launch(cameraIntent)
-        }
+        // 실행할 액티비티를 카메라 액티비티로 지정한다.
+        // 단말기에 설치되어 있는 모든 애플리케이션이 가진 액티비티 중에 사진촬영이
+        // 가능한 액티비가 실행된다.
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        // 이미지가 저장될 경로를 가지고 있는 Uri 객체를 인텐트에 담아준다.
+        cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
+        // 카메라 액티비티 실행
+        cameraLauncher.launch(cameraIntent)
     }
 
     // 앨범 런처 설정
@@ -185,7 +182,7 @@ class ModifyAuthorInfoFragment : Fragment() {
 
     }
 
-    // 카메라 런처를 실행하는 메서드
+    // 앨범 런처를 실행하는 메서드
     fun startAlbumLauncher(){
 
     }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/ModifyAuthorInfoFragment.kt
@@ -3,7 +3,6 @@ package kr.co.lion.unipiece.ui.author
 import android.app.AlertDialog
 import android.content.DialogInterface
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.net.Uri
@@ -22,8 +21,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.UniPieceApplication
@@ -37,8 +34,6 @@ import kr.co.lion.unipiece.util.resize
 import kr.co.lion.unipiece.util.rotate
 import kr.co.lion.unipiece.util.setImage
 import java.io.File
-import java.io.FileOutputStream
-import kotlin.text.Typography.degree
 
 class ModifyAuthorInfoFragment : Fragment() {
 
@@ -259,6 +254,16 @@ class ModifyAuthorInfoFragment : Fragment() {
             lifecycleScope.launch {
                 // 이미지 변경이 있는 경우 스토리지에 이미지 업로드
                 if(checkImg){
+                    with(fragmentModifyAuthorInfoBinding){
+                        // 프로그래스 바 표시
+                        layoutProgressModifyAuthor.visibility = View.VISIBLE
+                        // 이미지 업로드 동안 버튼 클릭 방지
+                        imageViewModifyAuthor.isClickable = false
+                        buttonModifyAuthorImage.isClickable = false
+                        buttonModifyAuthorInfoConfirm.isClickable = false
+                        buttonModifyAuthorUpdateAuthor.isClickable = false
+                    }
+
                     val uploadResult: Boolean
                     if(albumImageUri != null){
                         // 앨범의 이미지를 선택해 변경한 경우
@@ -270,10 +275,19 @@ class ModifyAuthorInfoFragment : Fragment() {
                         val file = imageUri.path?.let { it1 -> File(it1) }
                         file?.delete()
                     }
+                    // 프로그래스 바 숨기기
+                    fragmentModifyAuthorInfoBinding.layoutProgressModifyAuthor.visibility = View.GONE
 
                     // 이미지 업로드 실패한 경우
                     if(!uploadResult){
                         Snackbar.make(requireActivity(), fragmentModifyAuthorInfoBinding.root, "통신 실패, 잠시후 다시 시도해주세요", Snackbar.LENGTH_SHORT).show()
+                        with(fragmentModifyAuthorInfoBinding){
+                            // 클릭 방지 해제
+                            imageViewModifyAuthor.isClickable = true
+                            buttonModifyAuthorImage.isClickable = true
+                            buttonModifyAuthorInfoConfirm.isClickable = true
+                            buttonModifyAuthorUpdateAuthor.isClickable = true
+                        }
                         return@launch
                     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
@@ -32,7 +32,7 @@ class ModifyAuthorInfoViewModel: ViewModel() {
     }
 
     // 작가 이미지 업로드
-    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean{
+    suspend fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean{
         return authorInfoRepository.uploadImage(authorIdx, imageUri)
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/viewmodel/ModifyAuthorInfoViewModel.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.unipiece.ui.author.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -30,7 +31,10 @@ class ModifyAuthorInfoViewModel: ViewModel() {
         return authorInfoRepository.getAuthorInfoImg(authorImg)
     }
 
-    // 작가 이미지 셋팅
+    // 작가 이미지 업로드
+    fun uploadImage(authorIdx: Int, imageUri: Uri): Boolean{
+        return authorInfoRepository.uploadImage(authorIdx, imageUri)
+    }
 
 
     // 작가 정보 수정

--- a/app/src/main/res/layout/fragment_modify_author_info.xml
+++ b/app/src/main/res/layout/fragment_modify_author_info.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -11,7 +12,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:orientation="vertical"
         tools:context=".ui.author.ModifyAuthorInfoFragment">
 
@@ -40,7 +40,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="center_horizontal"
-                    android:orientation="horizontal">
+                    android:orientation="vertical">
 
                     <androidx.cardview.widget.CardView
                         android:id="@+id/cardViewImageModifyAuthor"
@@ -55,6 +55,13 @@
                             android:layout_height="match_parent"
                             android:src="@drawable/icon" />
                     </androidx.cardview.widget.CardView>
+
+                    <TextView
+                        android:id="@+id/buttonModifyAuthorImage"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이미지 변경하기"
+                        android:textColor="@color/first" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_modify_author_info.xml
+++ b/app/src/main/res/layout/fragment_modify_author_info.xml
@@ -26,6 +26,31 @@
             android:theme="?attr/actionBarTheme"
             app:titleTextAppearance="@style/Theme.Title.Toolbar" />
 
+        <LinearLayout
+            android:id="@+id/layoutProgressModifyAuthor"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/textViewProgressModifyAuthor"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginRight="10dp"
+                android:gravity="center"
+                android:text="수정 사항 저장 중..."
+                android:textSize="18sp" />
+
+            <ProgressBar
+                android:id="@+id/progressBarModifyAuthor"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminateTint="@color/first" />
+        </LinearLayout>
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent" >


### PR DESCRIPTION
## #️⃣연관된 이슈

> #178 

## 📝작업 내용

> 작가 정보 수정 기능 중 미구현 된 이미지 수정 기능 구현했습니다
> 카메라 촬영과 앨범에서 선택이 있습니다
> 수정하기 버튼을 누를때 이미지가 파이어베이스 스토리지에 업로드 됩니다.
> 이미지 업로드에 시간이 걸려 작가 정보 화면으로 돌아왔을 때 수정된 이미지로 바뀌지 않아서  업로드가 완료될 때까지 기다릴 수 있도록 동기 방식으로 수정 후 프로그래스 바를 추가했습니다

### 스크린샷 (선택)
[modifyauthor1.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/cebff32c-1e61-46ca-832e-fc5edcf23b66)

[modifyauthor2.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/ccd9be1e-42e9-44c1-b478-5c55e5266fa7)

[modifyauthor3.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/f9fe7355-a6a7-429b-aa40-94cc4c9df333)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
