### PR TITLE
[#190] 회원 정보 수정 탈퇴 기능

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/UserInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/UserInfoDataSource.kt
@@ -1,8 +1,8 @@
 package kr.co.lion.unipiece.db.remote
 
+import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
-import com.google.firebase.firestore.toObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -98,6 +98,41 @@ class UserInfoDataSource {
         job1.join()
 
         return userInfoData
+    }
+
+    // 유저 정보 업데이트
+    suspend fun updateUserData(userInfoData: UserInfoData):Boolean{
+        return try{
+            val userInfoDataMap = mapOf(
+                "userName" to userInfoData.userName,
+                "nickName" to userInfoData.nickName,
+                "phoneNumber" to userInfoData.phoneNumber,
+                "userPwd" to userInfoData.userPwd,
+            )
+            val collectionReference = db.collection("UserInfo")
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userInfoData.userIdx).get().await()
+            querySnapshot.documents[0].reference.update(userInfoDataMap).await()
+            true
+        }catch (e: Exception){
+            Log.e("Firebase Error", "Error updateUserData: ${e.message}")
+            false
+        }
+    }
+
+    // 회원 탈퇴 처리
+    suspend fun deleteUser(userIdx:Int):Boolean{
+        return try{
+            val userInfoDataMap = mapOf(
+                "userState" to false
+            )
+            val collectionReference = db.collection("UserInfo")
+            val querySnapshot = collectionReference.whereEqualTo("userIdx", userIdx).get().await()
+            querySnapshot.documents[0].reference.update(userInfoDataMap).await()
+            true
+        }catch (e: Exception){
+            Log.e("Firebase Error", "Error deleteUser: ${e.message}")
+            false
+        }
     }
 
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/UserInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/UserInfoRepository.kt
@@ -19,4 +19,8 @@ class UserInfoRepository {
 
     suspend fun getUserDataByUserId(userId: String) = userInfoDataSource.getUserDataByUserId(userId)
 
+    suspend fun updateUserData(userInfoData: UserInfoData):Boolean = userInfoDataSource.updateUserData(userInfoData)
+
+    suspend fun deleteUser(userIdx:Int):Boolean = userInfoDataSource.deleteUser(userIdx)
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -79,10 +79,6 @@ class ModifyUserInfoFragment : Fragment() {
 
         modifyUserInfoViewModel.deleteComplete.observe(viewLifecycleOwner){
             if(it){
-                Snackbar.make(requireView(),"회원 탈퇴 완료", Snackbar.LENGTH_SHORT)
-                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.first))
-                    .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
-                    .show()
                 // 로그인 화면으로 이동
                 val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
                 UniPieceApplication.prefs.deleteUserIdx("userIdx")

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -2,27 +2,18 @@ package kr.co.lion.unipiece.ui.mypage
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
-import androidx.core.content.ContextCompat.startActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.google.android.gms.tasks.Task
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
 import kr.co.lion.unipiece.UniPieceApplication
@@ -77,6 +68,27 @@ class ModifyUserInfoFragment : Fragment() {
                     .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
                     .show()
                 removeFragment()
+            }else{
+                Snackbar.make(requireView(),"네트워크 오류, 잠시 후 다시 시도해주세요", Snackbar.LENGTH_SHORT)
+                    .setAnchorView(fragmentModifyUserInfoBinding.toolbarModifyUserInfo)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.first))
+                    .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
+                    .show()
+            }
+        }
+
+        modifyUserInfoViewModel.deleteComplete.observe(viewLifecycleOwner){
+            if(it){
+                Snackbar.make(requireView(),"회원 탈퇴 완료", Snackbar.LENGTH_SHORT)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.first))
+                    .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
+                    .show()
+                // 로그인 화면으로 이동
+                val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
+                UniPieceApplication.prefs.deleteUserIdx("userIdx")
+                UniPieceApplication.prefs.deleteUserId("userId")
+                loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                startActivity(loginIntent)
             }else{
                 Snackbar.make(requireView(),"네트워크 오류, 잠시 후 다시 시도해주세요", Snackbar.LENGTH_SHORT)
                     .setAnchorView(fragmentModifyUserInfoBinding.toolbarModifyUserInfo)
@@ -181,12 +193,10 @@ class ModifyUserInfoFragment : Fragment() {
 
                 dialog.setButtonClickListener(object: CustomDialog.OnButtonClickListener{
                     override fun okButtonClick() {
-                        // 회원 탈퇴 처리
-
-                        // 로그인 화면으로 이동
-                        val loginIntent = Intent(requireActivity(), LoginActivity::class.java)
-                        loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        startActivity(loginIntent)
+                        lifecycleScope.launch {
+                            // 회원 탈퇴 처리
+                            modifyUserInfoViewModel.deleteUser()
+                        }
                     }
 
                     override fun noButtonClick() {

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ModifyUserInfoFragment.kt
@@ -2,14 +2,33 @@ package kr.co.lion.unipiece.ui.mypage
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.startActivity
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.gms.tasks.Task
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kr.co.lion.unipiece.R
+import kr.co.lion.unipiece.UniPieceApplication
 import kr.co.lion.unipiece.databinding.FragmentModifyUserInfoBinding
 import kr.co.lion.unipiece.ui.login.LoginActivity
+import kr.co.lion.unipiece.ui.mypage.viewmodel.ModifyUserInfoViewModel
 import kr.co.lion.unipiece.util.CustomDialog
 import kr.co.lion.unipiece.util.UserInfoFragmentName
 
@@ -17,19 +36,55 @@ class ModifyUserInfoFragment : Fragment() {
 
     lateinit var fragmentModifyUserInfoBinding: FragmentModifyUserInfoBinding
 
+    val modifyUserInfoViewModel:ModifyUserInfoViewModel by viewModels()
+
+    val userIdx by lazy {
+        UniPieceApplication.prefs.getUserIdx("userIdx", -1)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
 
-        fragmentModifyUserInfoBinding = FragmentModifyUserInfoBinding.inflate(inflater)
+        fragmentModifyUserInfoBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_modify_user_info, container, false)
+        fragmentModifyUserInfoBinding.modifyUserInfoViewModel = modifyUserInfoViewModel
+        fragmentModifyUserInfoBinding.lifecycleOwner = this
 
+        fetchData()
+        setObserver()
         settingToolbar()
         settingButtonModifyUserInfoConfirm()
         settingButtonDeleteUser()
 
         return fragmentModifyUserInfoBinding.root
+    }
+
+    private fun fetchData(){
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED){
+                modifyUserInfoViewModel.getUserDataByIdx(userIdx)
+            }
+        }
+    }
+
+    private fun setObserver(){
+        modifyUserInfoViewModel.checkComplete.observe(viewLifecycleOwner){
+            if(it){
+                Snackbar.make(requireView(),"회원 정보 수정 완료", Snackbar.LENGTH_SHORT)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.first))
+                    .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
+                    .show()
+                removeFragment()
+            }else{
+                Snackbar.make(requireView(),"네트워크 오류, 잠시 후 다시 시도해주세요", Snackbar.LENGTH_SHORT)
+                    .setAnchorView(fragmentModifyUserInfoBinding.toolbarModifyUserInfo)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.first))
+                    .setTextColor(ContextCompat.getColor(requireActivity(), R.color.white))
+                    .show()
+            }
+        }
     }
 
     // 툴바 셋팅
@@ -48,21 +103,73 @@ class ModifyUserInfoFragment : Fragment() {
 
     // 수정 완료 버튼
     private fun settingButtonModifyUserInfoConfirm(){
-        fragmentModifyUserInfoBinding.buttonModifyUserInfoConfirm.apply {
-            
-            // 추후 제거
-            setOnClickListener {
-                removeFragment()
+        fragmentModifyUserInfoBinding.buttonModifyUserInfoConfirm.setOnClickListener {
+            // 빈칸 확인
+            if(isInputEmpty()) return@setOnClickListener
+            // 비밀번호 확인 확인
+            if(checkPwd()) return@setOnClickListener
+            // 회원 정보 업데이트
+            lifecycleScope.launch {
+                modifyUserInfoViewModel.updateUserInfo()
             }
-            
-            // 입력 확인
-            
-            // 데이터 수정 처리
-            
-            // 회원 정보 프래그먼트로 이동
-
         }
+    }
+    
+    private fun isInputEmpty():Boolean{
+        resetError()
+        var result = false
+        with(fragmentModifyUserInfoBinding){
+            if(textInputModifyUserName.text.isNullOrBlank()){
+                layoutUserName.error = "이름을 입력해주세요"
+                result = true
+            }
+            if(textInputModifyUserNickName.text.isNullOrBlank()){
+                layoutUserNickName.error = "닉네임을 입력해주세요"
+                result = true
+            }
+            if(textInputModifyUserPhoneNumber.text.isNullOrBlank()){
+                layoutUserPhoneNumber.error = "휴대폰 번호를 입력해주세요"
+                result = true
+            }
+            if(textInputModifyUserPw.text.isNullOrBlank()){
+                layoutUserPw.error = "비밀번호를 입력해주세요"
+                result = true
+            }
+            if(textInputModifyUserPw2.text.isNullOrBlank()) {
+                layoutUserPw2.error = "비밀번호 확인을 입력해주세요"
+                result = true
+            }
+        }
+        return result
+    }
 
+    private fun resetError(){
+        with(fragmentModifyUserInfoBinding){
+            layoutUserName.error = ""
+            layoutUserName.isErrorEnabled = false
+            layoutUserNickName.error = ""
+            layoutUserNickName.isErrorEnabled = false
+            layoutUserPhoneNumber.error = ""
+            layoutUserPhoneNumber.isErrorEnabled = false
+            layoutUserPw.error = ""
+            layoutUserPw.isErrorEnabled = false
+            layoutUserPw2.error = ""
+            layoutUserPw2.isErrorEnabled = false
+        }
+    }
+
+    private fun checkPwd():Boolean{
+        var result = false
+        with(fragmentModifyUserInfoBinding){
+            layoutUserPw2.error = ""
+            layoutUserPw2.isErrorEnabled = false
+            // 비밀번호 입력값과 비밀번호 확인 입력값이 다르면 true를 반환하여 수정 버튼의 클릭리스너를 중단시킨다
+            if(textInputModifyUserPw.text.toString() != textInputModifyUserPw2.text.toString()){
+                layoutUserPw2.error = "입력하신 비밀번호와 다릅니다"
+                result = true
+            }
+        }
+        return result
     }
 
     // 회원 탈퇴 버튼

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/viewmodel/ModifyUserInfoViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/viewmodel/ModifyUserInfoViewModel.kt
@@ -1,0 +1,46 @@
+package kr.co.lion.unipiece.ui.mypage.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.model.UserInfoData
+import kr.co.lion.unipiece.repository.UserInfoRepository
+
+class ModifyUserInfoViewModel: ViewModel() {
+
+    // 회원 정보
+    private val _userInfoData = MutableLiveData<UserInfoData>()
+    val userInfoData: LiveData<UserInfoData> = _userInfoData
+
+    // 수정 완료 여부
+    val checkComplete = MutableLiveData<Boolean>()
+
+    // 회원 탈퇴 완료 여부
+    val deleteComplete = MutableLiveData<Boolean>()
+
+    private val userInfoRepository = UserInfoRepository()
+
+    // 회원 정보를 불러오기
+    suspend fun getUserDataByIdx(userIdx: Int) = viewModelScope.launch {
+        val job1 = launch {
+            _userInfoData.value = userInfoRepository.getUserDataByIdx(userIdx)
+            _userInfoData.value?.userPwd = ""
+        }
+        job1.join()
+    }
+
+    // 회원 정보 업데이트
+    suspend fun updateUserInfo() {
+        _userInfoData.value?.let { checkComplete.value = userInfoRepository.updateUserData(it) }
+    }
+
+    // 회원 탈퇴
+
+    suspend fun deleteUser() {
+        _userInfoData.value?.let { deleteComplete.value = userInfoRepository.deleteUser(it.userIdx) }
+    }
+
+}

--- a/app/src/main/res/layout/fragment_modify_user_info.xml
+++ b/app/src/main/res/layout/fragment_modify_user_info.xml
@@ -1,172 +1,184 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:transitionGroup="true">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="modifyUserInfoViewModel"
+            type="kr.co.lion.unipiece.ui.mypage.viewmodel.ModifyUserInfoViewModel" />
+    </data>
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbarModifyUserInfo"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="64dp"
-        android:background="@color/white"
-        android:minHeight="?attr/actionBarSize"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:theme="?attr/actionBarTheme"
-        app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:transitionGroup="true">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <LinearLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarModifyUserInfo"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="64dp"
+            android:background="@color/white"
+            android:minHeight="?attr/actionBarSize"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:theme="?attr/actionBarTheme"
+            app:titleTextAppearance="@style/Theme.Title.Toolbar" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:padding="20dp">
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layoutUserName"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="이름"
-                    app:boxStrokeColor="@color/second"
-                    app:cursorColor="@color/second"
-                    app:hintTextColor="@color/second">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/textInputModifyUserName"
-                        android:layout_width="match_parent"
-                        android:layout_height="56dp"
-                        android:background="@drawable/textfield_radius"
-                        android:inputType="text"
-                        android:paddingLeft="10dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layoutUserNickName"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="닉네임"
-                    app:boxStrokeColor="@color/second"
-                    app:cursorColor="@color/second"
-                    app:hintTextColor="@color/second">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/textInputModifyUserNickName"
-                        android:layout_width="match_parent"
-                        android:layout_height="56dp"
-                        android:background="@drawable/textfield_radius"
-                        android:inputType="text"
-                        android:paddingLeft="10dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layoutUserPhoneNumber"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="휴대폰 번호"
-                    app:boxStrokeColor="@color/second"
-                    app:cursorColor="@color/second"
-                    app:hintTextColor="@color/second">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/textInputModifyUserPhoneNumber"
-                        android:layout_width="match_parent"
-                        android:layout_height="56dp"
-                        android:background="@drawable/textfield_radius"
-                        android:inputType="text"
-                        android:maxLength="11"
-                        android:paddingLeft="10dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layoutUserPw"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="비밀번호"
-                    app:boxStrokeColor="@color/second"
-                    app:cursorColor="@color/second"
-                    app:endIconMode="password_toggle"
-                    app:hintTextColor="@color/second">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/textInputModifyUserPw"
-                        android:layout_width="match_parent"
-                        android:layout_height="56dp"
-                        android:background="@drawable/textfield_radius"
-                        android:inputType="text|textPassword"
-                        android:paddingLeft="10dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layoutUserPw2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="비밀번호 확인"
-                    app:boxStrokeColor="@color/second"
-                    app:cursorColor="@color/second"
-                    app:endIconMode="password_toggle"
-                    app:hintTextColor="@color/second">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/textInputModifyUserPw2"
-                        android:layout_width="match_parent"
-                        android:layout_height="56dp"
-                        android:background="@drawable/textfield_radius"
-                        android:inputType="text|textPassword"
-                        android:paddingLeft="10dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <Button
-                    android:id="@+id/buttonModifyUserInfoConfirm"
-                    android:layout_width="match_parent"
-                    android:layout_height="40dp"
-                    android:layout_marginTop="16dp"
-                    android:layout_marginBottom="16dp"
-                    android:background="@drawable/button_radius"
-                    android:text="수정완료"
-                    android:textColor="@color/white"
-                    android:textSize="18sp" />
-            </LinearLayout>
-
-            <com.google.android.material.divider.MaterialDivider
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:dividerColor="@color/lightgray"
-                app:dividerInsetEnd="16dp"
-                app:dividerInsetStart="16dp" />
+                android:orientation="vertical">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:padding="20dp">
-
-                <Button
-                    android:id="@+id/buttonDeleteUser"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="40dp"
-                    android:text="회원 탈퇴"
-                    android:textAlignment="center"
-                    android:textColor="@color/first"
-                    android:textSize="16sp" />
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layoutUserName"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="이름"
+                        app:boxStrokeColor="@color/second"
+                        app:cursorColor="@color/second"
+                        app:hintTextColor="@color/second">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/textInputModifyUserName"
+                            android:layout_width="match_parent"
+                            android:layout_height="56dp"
+                            android:background="@drawable/textfield_radius"
+                            android:inputType="text"
+                            android:paddingLeft="10dp"
+                            android:text="@={modifyUserInfoViewModel.userInfoData.userName}" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layoutUserNickName"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="닉네임"
+                        app:boxStrokeColor="@color/second"
+                        app:cursorColor="@color/second"
+                        app:hintTextColor="@color/second">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/textInputModifyUserNickName"
+                            android:layout_width="match_parent"
+                            android:layout_height="56dp"
+                            android:background="@drawable/textfield_radius"
+                            android:inputType="text"
+                            android:paddingLeft="10dp"
+                            android:text="@={modifyUserInfoViewModel.userInfoData.nickName}" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layoutUserPhoneNumber"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="휴대폰 번호"
+                        app:boxStrokeColor="@color/second"
+                        app:cursorColor="@color/second"
+                        app:hintTextColor="@color/second">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/textInputModifyUserPhoneNumber"
+                            android:layout_width="match_parent"
+                            android:layout_height="56dp"
+                            android:background="@drawable/textfield_radius"
+                            android:inputType="text"
+                            android:maxLength="11"
+                            android:paddingLeft="10dp"
+                            android:text="@={modifyUserInfoViewModel.userInfoData.phoneNumber}" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layoutUserPw"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="비밀번호"
+                        app:boxStrokeColor="@color/second"
+                        app:cursorColor="@color/second"
+                        app:endIconMode="password_toggle"
+                        app:hintTextColor="@color/second">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/textInputModifyUserPw"
+                            android:layout_width="match_parent"
+                            android:layout_height="56dp"
+                            android:background="@drawable/textfield_radius"
+                            android:inputType="text|textPassword"
+                            android:paddingLeft="10dp"
+                            android:text="@={modifyUserInfoViewModel.userInfoData.userPwd}" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layoutUserPw2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="비밀번호 확인"
+                        app:boxStrokeColor="@color/second"
+                        app:cursorColor="@color/second"
+                        app:endIconMode="password_toggle"
+                        app:hintTextColor="@color/second">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/textInputModifyUserPw2"
+                            android:layout_width="match_parent"
+                            android:layout_height="56dp"
+                            android:background="@drawable/textfield_radius"
+                            android:inputType="text|textPassword"
+                            android:paddingLeft="10dp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <Button
+                        android:id="@+id/buttonModifyUserInfoConfirm"
+                        android:layout_width="match_parent"
+                        android:layout_height="40dp"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginBottom="16dp"
+                        android:background="@drawable/button_radius"
+                        android:text="수정완료"
+                        android:textColor="@color/white"
+                        android:textSize="18sp" />
+                </LinearLayout>
+
+                <com.google.android.material.divider.MaterialDivider
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:dividerColor="@color/lightgray"
+                    app:dividerInsetEnd="16dp"
+                    app:dividerInsetStart="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <Button
+                        android:id="@+id/buttonDeleteUser"
+                        style="@style/Widget.MaterialComponents.Button.TextButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="40dp"
+                        android:text="회원 탈퇴"
+                        android:textAlignment="center"
+                        android:textColor="@color/first"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+
             </LinearLayout>
+        </ScrollView>
 
-
-        </LinearLayout>
-    </ScrollView>
-
-</LinearLayout>
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_modify_user_info.xml
+++ b/app/src/main/res/layout/fragment_modify_user_info.xml
@@ -33,6 +33,7 @@
                 android:padding="20dp">
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layoutUserName"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="이름"
@@ -50,6 +51,7 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layoutUserNickName"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
@@ -68,6 +70,7 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layoutUserPhoneNumber"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
@@ -82,16 +85,19 @@
                         android:layout_height="56dp"
                         android:background="@drawable/textfield_radius"
                         android:inputType="text"
+                        android:maxLength="11"
                         android:paddingLeft="10dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layoutUserPw"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:hint="비밀번호"
                     app:boxStrokeColor="@color/second"
                     app:cursorColor="@color/second"
+                    app:endIconMode="password_toggle"
                     app:hintTextColor="@color/second">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -99,17 +105,19 @@
                         android:layout_width="match_parent"
                         android:layout_height="56dp"
                         android:background="@drawable/textfield_radius"
-                        android:inputType="text"
+                        android:inputType="text|textPassword"
                         android:paddingLeft="10dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layoutUserPw2"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:hint="비밀번호 확인"
                     app:boxStrokeColor="@color/second"
                     app:cursorColor="@color/second"
+                    app:endIconMode="password_toggle"
                     app:hintTextColor="@color/second">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -117,7 +125,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="56dp"
                         android:background="@drawable/textfield_radius"
-                        android:inputType="text"
+                        android:inputType="text|textPassword"
                         android:paddingLeft="10dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #190 

## 📝작업 내용

> 회원 정보 수정
> 회원 탈퇴
> UserInfoDataSource, UserInfoRepository 수정이 있었습니다 참고 부탁드리겠습니다

### 스크린샷 (선택)
[modifyuser.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/71d6f389-ce27-4f52-a262-bee320745c9f)

[modifyuser2.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/abe9a2ff-9f2c-4cf4-9222-3913b841c93d)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 회원 정보 수정할 때 이름도 작가 이름처럼 수정 못하게 막아놓으면 될지요?
> 회원 탈퇴 시 회원 정보의 userState값이 false로 변경됩니다. 로그인 할 때 userState 확인하는 과정 추가가 필요할 것 같습니다
