### PR TITLE
[#246] layout xml 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/author/AuthorReviewBottomSheetFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -107,6 +108,7 @@ class AuthorReviewBottomSheetFragment : BottomSheetDialogFragment() {
             layoutManager = LinearLayoutManager(requireActivity())
             // 데코레이션
             val deco = MaterialDividerItemDecoration(requireActivity(), MaterialDividerItemDecoration.VERTICAL)
+            deco.dividerColor = ContextCompat.getColor(requireActivity(), R.color.lightgray)
             addItemDecoration(deco)
         }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ApplyVisitGalleryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/ApplyVisitGalleryFragment.kt
@@ -1,16 +1,24 @@
 package kr.co.lion.unipiece.ui.mypage
 
 import android.annotation.SuppressLint
+import android.graphics.text.LineBreaker
+import android.icu.lang.UCharacter.LineBreak
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.Animation
+import android.view.animation.LinearInterpolator
+import android.view.animation.TranslateAnimation
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.DateValidatorPointForward
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -54,6 +62,7 @@ class ApplyVisitGalleryFragment : Fragment() {
         fragmentApplyVisitGalleryBinding.lifecycleOwner = this
 
         fetchData()
+        settingTextViewAvailableTime()
         settingToolbar()
         settingButtonMember()
         settingDatePicker()
@@ -75,6 +84,14 @@ class ApplyVisitGalleryFragment : Fragment() {
                 applyVisitGalleryViewModel.setEmptyData(emptyData)
             }
             fragmentApplyVisitGalleryBinding.progressBarApplyVisit.visibility = View.GONE
+        }
+    }
+
+    private fun settingTextViewAvailableTime(){
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED){
+                fragmentApplyVisitGalleryBinding.textViewAvailableTime.isSelected = true
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/VisitGalleryHistoryFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
@@ -134,7 +135,8 @@ class VisitGalleryHistoryFragment : Fragment() {
             // 레이아웃 매니저
             layoutManager = LinearLayoutManager(requireActivity())
             // 데코레이션
-            val deco = MaterialDividerItemDecoration(requireActivity(), MaterialDividerItemDecoration.VERTICAL)
+            val deco = MaterialDividerItemDecoration(requireActivity(), DividerItemDecoration.VERTICAL)
+            deco.dividerColor = ContextCompat.getColor(requireActivity(), R.color.lightgray)
             addItemDecoration(deco)
         }
 

--- a/app/src/main/res/layout/fragment_apply_visit_gallery.xml
+++ b/app/src/main/res/layout/fragment_apply_visit_gallery.xml
@@ -26,15 +26,24 @@
             android:theme="?attr/actionBarTheme"
             app:titleTextAppearance="@style/Theme.Title.Toolbar" />
 
-        <TextView
-            android:id="@+id/textViewAvailableTime"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/lightgray"
-            android:padding="10dp"
-            android:text="방문 가능 시간대는 09:00 ~ 12:00, 13:00 ~ 17:00 입니다."
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:background="@color/lightgray">
+
+            <TextView
+                android:id="@+id/textViewAvailableTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+
+                android:ellipsize="marquee"
+                android:marqueeRepeatLimit="marquee_forever"
+                android:padding="10dp"
+                android:singleLine="true"
+                android:text="방문 가능 시간대는 09:00 ~ 12:00, 13:00 ~ 17:00 입니다."
+                android:textSize="16sp"
+                android:textStyle="bold" />
+        </LinearLayout>
 
         <ProgressBar
             android:id="@+id/progressBarApplyVisit"

--- a/app/src/main/res/layout/fragment_apply_visit_gallery.xml
+++ b/app/src/main/res/layout/fragment_apply_visit_gallery.xml
@@ -92,6 +92,7 @@
                         android:layout_height="56dp"
                         android:background="@drawable/textfield_radius"
                         android:inputType="text|textPhonetic"
+                        android:maxLength="11"
                         android:paddingLeft="10dp"
                         android:text="@={viewModel.visitAddData.visitorPhone}" />
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/fragment_author_info.xml
+++ b/app/src/main/res/layout/fragment_author_info.xml
@@ -31,7 +31,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            tools:visibility="gone">
 
             <ProgressBar
                 android:id="@+id/progressBarAuthorInfo"
@@ -39,14 +40,16 @@
                 android:layout_width="50dp"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
-                android:indeterminateTint="@color/first" />
+                android:indeterminateTint="@color/first"
+                tools:visibility="gone" />
         </LinearLayout>
 
         <ScrollView
             android:id="@+id/scrollViewAuthorInfo"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone">
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -129,7 +132,8 @@
                                 android:textColor="@color/first"
                                 android:textSize="14sp"
                                 android:textStyle="bold"
-                                android:visibility="invisible" />
+                                android:visibility="invisible"
+                                tools:visibility="visible" />
 
                             <Button
                                 android:id="@+id/buttonAuthorReview"
@@ -144,7 +148,8 @@
                                 android:textColor="@color/white"
                                 android:textSize="14sp"
                                 android:textStyle="bold"
-                                android:visibility="invisible" />
+                                android:visibility="invisible"
+                                tools:visibility="visible" />
                         </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>
@@ -174,9 +179,11 @@
                 <TextView
                     android:id="@+id/textViewAuthorDetailInfo"
                     android:layout_width="match_parent"
-                    android:layout_height="150dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
                     android:background="@drawable/textfield_radius"
+                    android:maxHeight="300dp"
+                    android:minHeight="150dp"
                     android:padding="16dp"
                     android:text=""
                     android:textColor="@color/black" />

--- a/app/src/main/res/layout/fragment_modify_author_info.xml
+++ b/app/src/main/res/layout/fragment_modify_author_info.xml
@@ -118,6 +118,7 @@
                     android:hint="기본 정보"
                     app:boxStrokeColor="@color/second"
                     app:cursorColor="@color/second"
+                    app:endIconMode="clear_text"
                     app:hintTextColor="@color/second">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -127,7 +128,7 @@
                         android:background="@drawable/textfield_radius"
                         android:inputType="text"
                         android:paddingLeft="10dp"
-                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorBasic}"/>
+                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorBasic}" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
@@ -137,16 +138,18 @@
                     android:hint="작가 소개"
                     app:boxStrokeColor="@color/second"
                     app:cursorColor="@color/second"
+                    app:endIconMode="clear_text"
                     app:hintTextColor="@color/second">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/textInputModifyAuthorDetailInfo"
                         android:layout_width="match_parent"
-                        android:layout_height="56dp"
+                        android:layout_height="wrap_content"
                         android:background="@drawable/textfield_radius"
                         android:inputType="text|textMultiLine"
+                        android:minHeight="56dp"
                         android:paddingLeft="10dp"
-                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorInfo}"/>
+                        android:text="@={modifyAuthorInfoViewModel.authorInfoData.authorInfo}" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <Button

--- a/app/src/main/res/layout/fragment_modify_user_info.xml
+++ b/app/src/main/res/layout/fragment_modify_user_info.xml
@@ -46,6 +46,7 @@
                         android:hint="이름"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -66,6 +67,7 @@
                         android:hint="닉네임"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -86,6 +88,7 @@
                         android:hint="휴대폰 번호"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -93,7 +96,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="56dp"
                             android:background="@drawable/textfield_radius"
-                            android:inputType="text"
+                            android:inputType="number"
                             android:maxLength="11"
                             android:paddingLeft="10dp"
                             android:text="@={modifyUserInfoViewModel.userInfoData.phoneNumber}" />

--- a/app/src/main/res/layout/fragment_modify_user_info.xml
+++ b/app/src/main/res/layout/fragment_modify_user_info.xml
@@ -46,6 +46,7 @@
                         android:hint="이름"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -66,6 +67,7 @@
                         android:hint="닉네임"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -86,6 +88,7 @@
                         android:hint="휴대폰 번호"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
+                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/fragment_modify_user_info.xml
+++ b/app/src/main/res/layout/fragment_modify_user_info.xml
@@ -46,7 +46,6 @@
                         android:hint="이름"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
-                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -67,7 +66,6 @@
                         android:hint="닉네임"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
-                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText
@@ -88,7 +86,6 @@
                         android:hint="휴대폰 번호"
                         app:boxStrokeColor="@color/second"
                         app:cursorColor="@color/second"
-                        app:endIconMode="clear_text"
                         app:hintTextColor="@color/second">
 
                         <com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
## #️⃣연관된 이슈

> #246 

## 📝작업 내용

> TextInputLayout의 endIconMode=clear_text 추가
> 작가 소개 textview의 minHeight 추가
> 리사이클러뷰 구분선 lightgrey로 수정
> 전시실 방문 시간대 안내 textview 애니메이션 추가

### 스크린샷 (선택)
화면이 작은 기기의 경우 안내문구가 줄바꿈이 발생하거나 짤릴 수 있는 부분을 elipsize=marquee 속성으로 수정했습니다
<img width="50%" src="https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/ca6ee725-50ee-4dbb-8f67-48753588f39a"></img>

리사이클러뷰 구분선은 이전의 분홍색? 대신 lightgrey로 수정
![image](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/121005637/bcfcfacb-9d5f-4ee7-9e35-55a810a4ebce)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
