### PR TITLE
[Feat]#264 장바구니 체크박스, 팔로우목록 DB연동, 클릭이벤트

### DIFF
--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorFollowDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorFollowDataSource.kt
@@ -1,11 +1,16 @@
 package kr.co.lion.unipiece.db.remote
 
+import android.util.Log
 import com.google.firebase.Firebase
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kr.co.lion.unipiece.model.AuthorInfoData
+import kr.co.lion.unipiece.model.CartData
+import kr.co.lion.unipiece.model.PieceInfoData
 
 class AuthorFollowDataSource {
     private val db = Firebase.firestore
@@ -79,4 +84,42 @@ class AuthorFollowDataSource {
         }
         job1.join()
     }
+
+    // userIdx에 해당하는 authorIdx들로 작가 정보들을 들고온다.
+    suspend fun getAuthorIdxsByUserIdx(userIdx: Int): List<Int> {
+        return try {
+            val followQuery = db.collection("Following").whereEqualTo("userIdx", userIdx)
+            val followQuerySnapshot = followQuery.get().await()
+            followQuerySnapshot.map { it.toObject(AuthorInfoData::class.java).authorIdx }.distinct()
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error in getAuthorIdxsByUserIdx: ${e.message}")
+            emptyList()
+        }
+    }
+
+//    // userIdx에 해당하는 authorIdx들로 작가 정보들을 들고온다.
+//    suspend fun getFollowDataByUserIdx(userIdx: Int): List<AuthorInfoData> {
+//        return try {
+//            // Following 컬렉션에서 userIdx로 팔로우 데이터 가져오기
+//            val followQuery = db.collection("Following").whereEqualTo("userIdx", userIdx)
+//            val followQuerySnapshot = followQuery.get().await()
+//            // 팔로우 데이터에서 pieceIdx 추출하기
+//            val authorIdxs = followQuerySnapshot.map { it.toObject(AuthorInfoData::class.java).authorIdx }.distinct()
+//
+//            // 작품 정보를 담을 리스트 초기화
+//            val authorInfoList = mutableListOf<AuthorInfoData>()
+//
+//            // PieceInfo 컬렉션에서 각 pieceIdx에 해당하는 작품 정보 가져오기
+//            for (authorIdx in authorIdxs) {
+//                val authorInfoQuery = db.collection("AuthorInfo").whereEqualTo("authorIdx", authorIdx)
+//                val authorInfoQuerySnapshot = authorInfoQuery.get().await()
+//                authorInfoList.addAll(authorInfoQuerySnapshot.map { it.toObject(AuthorInfoData::class.java) })
+//            }
+//
+//            return authorInfoList
+//        } catch (e: Exception) {
+//            Log.e("Firebase Error", "Error in getCartDataByUserIdx: ${e.message}")
+//            emptyList()
+//        }
+//    }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/db/remote/AuthorInfoDataSource.kt
@@ -272,4 +272,33 @@ class AuthorInfoDataSource {
         }
     }
 
+    // 작가정보들을 가져와서 각각의 작가정보를 반환한다.
+    suspend fun getAuthorInfoByAuthorIdxs(authorIdxs: List<Int>): List<AuthorInfoData> {
+        val authorInfoList = mutableListOf<AuthorInfoData>()
+        try {
+            for (authorIdx in authorIdxs) {
+                val authorInfoQuery = db.collection("AuthorInfo").whereEqualTo("authorIdx", authorIdx)
+                val authorInfoQuerySnapshot = authorInfoQuery.get().await()
+                authorInfoList.addAll(authorInfoQuerySnapshot.map { it.toObject(AuthorInfoData::class.java) })
+            }
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error in getAuthorInfoByAuthorIdxs: ${e.message}")
+        }
+        return authorInfoList
+    }
+
+    // 작가 이미지 url 받아오기
+    suspend fun getAuthorInfoImg(authorIdx: String, authorImg: String): String? {
+
+        val authorImgData = "${authorIdx}.jpg"
+
+        val path = "AuthorInfo/$authorImgData"
+        return try {
+            storage.child(path).downloadUrl.await().toString()
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error getAuthorInfoImg: ${e.message} ${path}")
+            null
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorFollowRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorFollowRepository.kt
@@ -16,4 +16,6 @@ class AuthorFollowRepository {
 
     // 작가 팔로우 취소
     suspend fun cancelFollowing(userIdx:Int, authorIdx:Int) = authorFollowDataSource.cancelFollowing(userIdx, authorIdx)
+
+    suspend fun getAuthorIdxsByUserIdx(userIdx: Int) = authorFollowDataSource.getAuthorIdxsByUserIdx(userIdx)
 }

--- a/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/repository/AuthorInfoRepository.kt
@@ -51,4 +51,9 @@ class AuthorInfoRepository {
 
     suspend fun searchAuthor(authorName: String) = authorInfoDataSource.searchAuthor(authorName)
 
+    suspend fun getAuthorInfoByAuthorIdxs(authorIdxs: List<Int>) = authorInfoDataSource.getAuthorInfoByAuthorIdxs(authorIdxs)
+
+    // 작가 이미지 url 받아오기
+    suspend fun getAuthorInfoImg(authorIdx: String,authorImg:String) = authorInfoDataSource.getAuthorInfoImg(authorIdx,authorImg)
+
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/FollowAdapter.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/adapter/FollowAdapter.kt
@@ -1,7 +1,9 @@
 package kr.co.lion.unipiece.ui.mypage.adapter
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.OnClickListener
 import android.view.ViewGroup
@@ -12,6 +14,7 @@ import kr.co.lion.unipiece.model.AuthorInfoData
 import kr.co.lion.unipiece.model.DeliveryData
 import kr.co.lion.unipiece.ui.author.AuthorInfoActivity
 import kr.co.lion.unipiece.util.CustomDialog
+import kr.co.lion.unipiece.util.setImage
 
 // 메인 화면의 RecyclerView의 어뎁터
 class FollowAdapter(
@@ -40,6 +43,13 @@ class FollowAdapter(
         holder.bind(authorinfoList[position],rowClickListener)
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(list: List<AuthorInfoData>) {
+        authorinfoList = list
+        notifyDataSetChanged()
+        Log.d("update adapter", list.toString())
+    }
+
 
 }
 
@@ -55,30 +65,39 @@ class FollowViewHolder(
         with(binding) {
 
             // 항목 클릭 시
-            root.setOnClickListener{
-                rowClickListener.invoke(data.authorIdx)
+            with(root){
+                setOnClickListener{
+                    rowClickListener.invoke(data.authorIdx)
+                }
+                // 항목 클릭 시 클릭되는 범위 설정
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+
+
             }
 
-            // 프로필 사진을 클릭 시
-            ivProfileImage.setOnClickListener {
-                rowClickListener.invoke(data.authorIdx)
+            // 프로필 사진
+            root.context.setImage(imageViewFollowingAuthor,data.authorImg)
+            with(ivProfileImage){
+                // 사진 클릭 시
+                setOnClickListener {
+                    rowClickListener.invoke(data.authorIdx)
+                }
             }
+
+            textViewFollowerCount.text = "팔로워 ${data.authorFollow}"
+            textViewFollowListAuthorName.text = "${data.authorName}"
 
             // 항목별 팔로우 취소 텍스트 버튼 클릭 시
-            textButtonFollowCancel.setOnClickListener {
-                followCancelButtonOnClickListener.invoke(data.authorIdx)
+            with(textButtonFollowCancel){
+                setOnClickListener {
+                    followCancelButtonOnClickListener.invoke(data.authorIdx)
+                }
             }
 
-            // 항목 클릭 시 클릭되는 범위 설정
-            root.layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            )
+
         }
-
-
-
-
-
     }
 }

--- a/app/src/main/java/kr/co/lion/unipiece/ui/mypage/viewmodel/FollowViewModel.kt
+++ b/app/src/main/java/kr/co/lion/unipiece/ui/mypage/viewmodel/FollowViewModel.kt
@@ -1,9 +1,83 @@
 package kr.co.lion.unipiece.ui.mypage.viewmodel
 
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.lion.unipiece.UniPieceApplication
+import kr.co.lion.unipiece.model.AuthorInfoData
+import kr.co.lion.unipiece.repository.AuthorFollowRepository
+import kr.co.lion.unipiece.repository.AuthorInfoRepository
 
 class FollowViewModel : ViewModel() {
 
-    // 내가 팔로우한 작가들의 정보를 불러온다.
+    private val authorFollowRepository = AuthorFollowRepository()
+    private val authorInfoRepository = AuthorInfoRepository()
 
+    // 유저 Idx 찾기
+    val userIdx = UniPieceApplication.prefs.getUserIdx("userIdx", 0)
+
+    // userIdx로 가져온 작가 리스트
+    private val _userIdxAuthorInfoDataList = MutableLiveData<List<AuthorInfoData>>()
+    val userIdxAuthorInfoDataList: LiveData<List<AuthorInfoData>> = _userIdxAuthorInfoDataList
+
+    // userIdx로 팔로우한 작가 리스트 가져오기 로딩
+    private val _userIdxAuthorInfoDataLoading = MutableLiveData<Boolean?>(null)
+    val userIdxAuthorInfoDataLoading : LiveData<Boolean?> = _userIdxAuthorInfoDataLoading
+
+    // 팔로우 취소 로딩
+    private val _cancelFollowingLoading = MutableLiveData<Boolean?>(null)
+    val cancelFollowingLoading : LiveData<Boolean?> = _cancelFollowingLoading
+
+    init {
+        viewModelScope.launch {
+            getFollowDataByUserIdx(userIdx)
+        }
+    }
+
+    fun userIdxAuthorInfoDataLoading() {
+        _userIdxAuthorInfoDataLoading.value = null
+    }
+
+    fun cancelFollowingLoading(){
+        _cancelFollowingLoading.value = null
+    }
+
+
+    // userIdx로 내가 팔로우한 작가들의 정보를 들고온다.
+    fun getFollowDataByUserIdx(userIdx: Int) = viewModelScope.launch {
+        try {
+            val authorIdxs = authorFollowRepository.getAuthorIdxsByUserIdx(userIdx)
+            val response = authorInfoRepository.getAuthorInfoByAuthorIdxs(authorIdxs)
+            val updateAuthorInfoList = updateImageAuthorInfo(response)
+            _userIdxAuthorInfoDataList.value = updateAuthorInfoList
+            _userIdxAuthorInfoDataLoading.value = true
+        } catch (e: Exception) {
+            Log.e("Firebase Error", "Error vmGetFollowDataByUserIdx : ${e.message}")
+        }
+
+    }
+
+
+    // 팔로우 취소
+    suspend fun cancelFollowing(userIdx: Int, authorIdx: Int) {
+        val job1 = viewModelScope.launch {
+            authorFollowRepository.cancelFollowing(userIdx, authorIdx)
+            _cancelFollowingLoading.value = true
+        }
+        job1.join()
+    }
+
+    suspend fun updateImageAuthorInfo(authorInfoList: List<AuthorInfoData>): List<AuthorInfoData> {
+        return authorInfoList.map { authorInfoData ->
+            val authorImgUrl = getPieceImg(authorInfoData.authorIdx.toString(), authorInfoData.authorImg)
+            authorInfoData.copy(authorImg = authorImgUrl ?: authorInfoData.authorImg)
+        }
+    }
+
+    private suspend fun getPieceImg(authorIdx: String, authorImg: String): String? {
+        return authorInfoRepository.getAuthorInfoImg(authorIdx, authorImg)
+    }
 }

--- a/app/src/main/res/layout/row_follow.xml
+++ b/app/src/main/res/layout/row_follow.xml
@@ -37,13 +37,15 @@
                     android:layout_height="wrap_content"
                     android:src="@drawable/icon" />
             </androidx.cardview.widget.CardView>
+
             <TextView
+                android:id="@+id/textViewFollowerCount"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="팔로워 123"
-                android:textColor="@color/black"
                 android:textAlignment="center"
-                android:textSize="15sp"/>
+                android:textColor="@color/black"
+                android:textSize="15sp" />
 
             <TextView
                 android:id="@+id/textViewFollowListAuthorName"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #264 

## 📝작업 내용

> 장바구니 및 주문하기 리사이클러뷰 클릭 이벤트 구현.
> 팔로우목록 클릭 이벤트 및 DB연동
> 장바구니 전체선택 및 선택삭제기능 구현

### 스크린샷 (선택)
[팔로우목록.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/334d8d8a-1e86-4583-855b-6bef3d5d799d)
[전체선택선택삭제.webm](https://github.com/APP-Android2/FinalProject-ShoppingMallService-team6/assets/79239041/77b62761-3bc2-4cd3-969c-fc19980e4a90)



## 💬리뷰 요구사항(선택)
